### PR TITLE
Fix hosted feed overwrite when creating new album

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { NostrProvider, useNostr } from './store/nostrStore.tsx';
 import { ThemeProvider, useTheme } from './store/themeStore.tsx';
 import { parseRssFeed, isPublisherFeed, isVideoFeed, parsePublisherRssFeed } from './utils/xmlParser';
 import { createEmptyAlbum, createEmptyPublisherFeed, createEmptyVideoAlbum } from './types/feed';
+import { pendingHostedStorage } from './utils/storage';
 import { generateTestAlbum } from './utils/testData';
 import { NostrLoginButton } from './components/NostrLoginButton';
 import { ImportModal } from './components/modals/ImportModal';
@@ -89,6 +90,8 @@ function AppContent() {
   };
 
   const handleLoadAlbum = (album: Album) => {
+    // Clear stale hosted credentials - Nostr/music imports don't use pending hosted storage
+    pendingHostedStorage.clear();
     dispatch({ type: 'SET_ALBUM', payload: album });
   };
 
@@ -98,6 +101,9 @@ function AppContent() {
   };
 
   const handleConfirmNew = () => {
+    // Clear any stale hosted import credentials so they don't
+    // accidentally overwrite a previously imported feed's content
+    pendingHostedStorage.clear();
     if (pendingNewFeedType === 'publisher') {
       dispatch({ type: 'SET_PUBLISHER_FEED', payload: createEmptyPublisherFeed() });
     } else if (pendingNewFeedType === 'video') {

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -125,7 +125,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
     // Check for pending credentials from import
     const pending = pendingHostedStorage.load();
     if (pending) {
-      // If pending feedId matches podcastGuid, use it; otherwise it's legacy
+      // Only use pending credentials if they match the current feed's GUID
       if (pending.feedId === currentFeedGuid) {
         saveHostedFeedInfo(currentFeedGuid, pending);
         pendingHostedStorage.clear();
@@ -133,9 +133,9 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
         setHostedUrl(buildHostedUrl(pending.feedId));
         return;
       } else {
-        // Legacy feed with mismatched ID - save as legacy, will update both on save
+        // Pending credentials don't match current feed - discard them
+        // (They're stale from a previous import, not a legacy migration)
         pendingHostedStorage.clear();
-        setLegacyHostedInfo(pending);
       }
     }
 


### PR DESCRIPTION
When a user imported a hosted feed and then created a new album, stale
pending hosted credentials were misidentified as a legacy feed migration.
This caused the old album's hosted feed to be overwritten with the new
album's content on save.

The fix:
- Discard non-matching pending credentials in SaveModal instead of
  treating them as legacy migration candidates
- Clear pending hosted storage when creating new albums or loading
  from Nostr, since those flows don't set their own pending credentials

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01DqsPjvZXentUNCzUCbodDE