### PR TITLE
Add timestamped feed backups with list and restore endpoints

### DIFF
--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -36,7 +36,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     try {
       const { blobs } = await list({ prefix: 'feeds/' });
       const metaBlobs = blobs.filter(b => b.pathname.endsWith('.meta.json'));
-      const xmlBlobs = blobs.filter(b => b.pathname.endsWith('.xml'));
+      const xmlBlobs = blobs.filter(b => b.pathname.endsWith('.xml') && !b.pathname.includes('.backup.'));
 
       let feeds = await Promise.all(
         metaBlobs.map(async (blob) => {


### PR DESCRIPTION
Save a timestamped backup (feeds/{id}.backup.{timestamp}.xml) before every feed update or delete. All versions are kept.

New admin-only endpoints:
- GET /api/hosted/{id}?backups - list available backups
- POST /api/hosted/{id}?backup={timestamp} - restore from a backup (also backs up the current version before restoring)

Backup files are filtered from the admin feed listing.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01DqsPjvZXentUNCzUCbodDE