### PR TITLE
Add missing Nostr music track tags per kind 36787 spec

### DIFF
--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -98,7 +98,7 @@ export interface NostrMusicTrackInfo {
   released?: string;
   language?: string;
   duration?: string;
-  explicit?: boolean;
+  explicit?: true;
   genres: string[];
   zapSplits: NostrZapSplit[];
   content: NostrMusicContent;

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -97,6 +97,8 @@ export interface NostrMusicTrackInfo {
   imageUrl?: string;
   released?: string;
   language?: string;
+  duration?: string;
+  explicit?: boolean;
   genres: string[];
   zapSplits: NostrZapSplit[];
   content: NostrMusicContent;

--- a/src/utils/nostrMusicConverter.test.ts
+++ b/src/utils/nostrMusicConverter.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { parseNostrMusicEvent } from './nostrMusicConverter';
+import type { NostrEvent } from '../types/nostr';
+
+function buildTrackEvent(overrides: { tags?: string[][]; content?: string } = {}): NostrEvent {
+  const baseTags: string[][] = [
+    ['d', 'track-guid-1'],
+    ['title', 'Test Track'],
+    ['url', 'https://example.com/track.mp3'],
+    ['artist', 'Test Artist'],
+    ['album', 'Test Album'],
+    ['track_number', '1'],
+  ];
+  return {
+    kind: 36787,
+    pubkey: 'abc123',
+    created_at: 1700000000,
+    tags: overrides.tags ? [...baseTags, ...overrides.tags] : baseTags,
+    content: overrides.content || '',
+    id: 'evt1',
+  };
+}
+
+describe('parseNostrMusicEvent', () => {
+  it('returns null when required tags are missing', () => {
+    const event: NostrEvent = {
+      kind: 36787,
+      pubkey: 'abc',
+      created_at: 0,
+      tags: [['d', 'id'], ['title', 'T']],
+      content: '',
+    };
+    expect(parseNostrMusicEvent(event)).toBeNull();
+  });
+
+  describe('duration parsing', () => {
+    it('parses a valid numeric duration', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({ tags: [['duration', '225']] }));
+      expect(result?.duration).toBe('225');
+    });
+
+    it('rejects non-numeric duration', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({ tags: [['duration', 'garbage']] }));
+      expect(result?.duration).toBeUndefined();
+    });
+
+    it('rejects duration with decimals', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({ tags: [['duration', '3.5']] }));
+      expect(result?.duration).toBeUndefined();
+    });
+
+    it('omits duration when tag is absent', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent());
+      expect(result?.duration).toBeUndefined();
+    });
+  });
+
+  describe('explicit parsing', () => {
+    it('parses explicit=true', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({ tags: [['explicit', 'true']] }));
+      expect(result?.explicit).toBe(true);
+    });
+
+    it('ignores explicit when value is not "true"', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({ tags: [['explicit', 'false']] }));
+      expect(result?.explicit).toBeUndefined();
+    });
+
+    it('omits explicit when tag is absent', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent());
+      expect(result?.explicit).toBeUndefined();
+    });
+  });
+
+  describe('genre filtering', () => {
+    it('excludes the "music" discriminator from genres', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({
+        tags: [['t', 'music'], ['t', 'rock'], ['t', 'indie']],
+      }));
+      expect(result?.genres).toEqual(['rock', 'indie']);
+    });
+
+    it('returns empty genres when only "music" tag exists', () => {
+      const result = parseNostrMusicEvent(buildTrackEvent({ tags: [['t', 'music']] }));
+      expect(result?.genres).toEqual([]);
+    });
+  });
+});

--- a/src/utils/nostrMusicConverter.ts
+++ b/src/utils/nostrMusicConverter.ts
@@ -272,8 +272,9 @@ export function parseNostrMusicEvent(event: NostrEvent): NostrMusicTrackInfo | n
     .map(t => t[1])
     .filter(v => v && v !== 'music');
 
-  // Parse duration and explicit
-  const duration = getTag('duration');
+  // Parse duration (must be numeric) and explicit
+  const rawDuration = getTag('duration');
+  const duration = rawDuration && /^\d+$/.test(rawDuration) ? rawDuration : undefined;
   const explicit = getTag('explicit');
 
   // Parse zap splits from 'zap' tags

--- a/src/utils/nostrMusicConverter.ts
+++ b/src/utils/nostrMusicConverter.ts
@@ -138,6 +138,14 @@ async function convertNostrTrackToTrack(
   // Build description from content
   track.description = buildTrackDescription(nostrTrack);
 
+  // Set duration and explicit
+  if (nostrTrack.duration) {
+    track.duration = nostrTrack.duration;
+  }
+  if (nostrTrack.explicit) {
+    track.explicit = true;
+  }
+
   // Set track art
   if (nostrTrack.imageUrl) {
     track.trackArtUrl = nostrTrack.imageUrl;
@@ -258,11 +266,15 @@ export function parseNostrMusicEvent(event: NostrEvent): NostrMusicTrackInfo | n
   // Required fields
   if (!dTag || !title || !url) return null;
 
-  // Parse genres from 't' tags
+  // Parse genres from 't' tags (exclude the "music" discriminator tag)
   const genres = event.tags
     .filter(t => t[0] === 't')
     .map(t => t[1])
-    .filter(Boolean);
+    .filter(v => v && v !== 'music');
+
+  // Parse duration and explicit
+  const duration = getTag('duration');
+  const explicit = getTag('explicit');
 
   // Parse zap splits from 'zap' tags
   const zapSplits: NostrZapSplit[] = event.tags
@@ -288,6 +300,8 @@ export function parseNostrMusicEvent(event: NostrEvent): NostrMusicTrackInfo | n
     imageUrl: getTag('image'),
     released: getTag('released'),
     language: getTag('language'),
+    duration: duration || undefined,
+    explicit: explicit === 'true' || undefined,
     genres,
     zapSplits,
     content: parsedContent,

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -522,7 +522,6 @@ function createMusicTrackEvent(
     ['artist', album.author || 'Unknown Artist'],
     ['album', album.title || 'Untitled'],
     ['track_number', String(track.trackNumber)],
-    ['t', 'music'],
     ['client', CLIENT_TAG],
     ['alt', `Music track: ${track.title} by ${album.author || 'Unknown Artist'}`]
   ];
@@ -554,7 +553,8 @@ function createMusicTrackEvent(
     tags.push(['language', album.language]);
   }
 
-  // Add genre tags from categories
+  // Add genre tags from categories (music discriminator first, then user genres)
+  tags.push(['t', 'music']);
   for (const category of album.categories) {
     tags.push(['t', category.toLowerCase()]);
   }

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -522,9 +522,20 @@ function createMusicTrackEvent(
     ['artist', album.author || 'Unknown Artist'],
     ['album', album.title || 'Untitled'],
     ['track_number', String(track.trackNumber)],
+    ['t', 'music'],
     ['client', CLIENT_TAG],
     ['alt', `Music track: ${track.title} by ${album.author || 'Unknown Artist'}`]
   ];
+
+  // Add duration
+  if (track.duration) {
+    tags.push(['duration', String(track.duration)]);
+  }
+
+  // Add explicit flag
+  if (track.explicit) {
+    tags.push(['explicit', 'true']);
+  }
 
   // Add image (track art or album art)
   const imageUrl = track.trackArtUrl || album.imageUrl;


### PR DESCRIPTION
- Add required ["t", "music"] discriminator tag to track events
- Emit duration tag from track.duration when present
- Emit explicit tag when track.explicit is true
- Parse duration and explicit on import in nostrMusicConverter
- Filter out "music" discriminator from genre categories on import
- Add duration/explicit fields to NostrMusicTrackInfo type

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_017ww8BuiQ2fzx2TCicuSrLd