### PR TITLE
Fix info card tooltip clipping off-screen on iOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "msp-2.0",
       "version": "0.1.03",
+      "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^3.0.0",
         "@vercel/blob": "^2.0.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1298,35 +1298,6 @@ body {
     min-height: 44px;
     padding: 10px;
   }
-
-  /* Info icon - larger touch target */
-  .info-icon-wrapper {
-    padding: 12px;
-    margin: -12px;
-    margin-left: -8px;
-  }
-
-  .info-icon {
-    width: 18px;
-    height: 18px;
-    font-size: 11px;
-  }
-
-  /* Tooltip adjustments */
-  .info-tooltip {
-    position: fixed;
-    left: 16px;
-    right: 16px;
-    top: auto;
-    bottom: 16px;
-    width: auto;
-    border: 1px solid var(--accent-primary);
-  }
-
-  .info-tooltip::before,
-  .info-tooltip::after {
-    display: none;
-  }
 }
 
 /* Small phones */
@@ -1549,6 +1520,42 @@ body {
     font-size: 0.7rem;
     color: var(--text-muted);
     font-style: italic;
+  }
+}
+
+@media (max-width: 768px) {
+  /* Info icon - larger touch target */
+  .info-icon-wrapper {
+    padding: 12px;
+    margin: -12px;
+    margin-left: -8px;
+  }
+
+  .info-icon {
+    width: 18px;
+    height: 18px;
+    font-size: 11px;
+  }
+
+  /* Anchor tooltip to the viewport so it never clips off-screen on narrow
+     devices, regardless of which side the InfoIcon chose. */
+  .info-tooltip,
+  .info-tooltip-left {
+    position: fixed;
+    left: 16px;
+    right: 16px;
+    top: auto;
+    bottom: 16px;
+    width: auto;
+    max-width: none;
+    border: 1px solid var(--accent-primary);
+  }
+
+  .info-tooltip::before,
+  .info-tooltip::after,
+  .info-tooltip-left::before,
+  .info-tooltip-left::after {
+    display: none;
   }
 }
 


### PR DESCRIPTION
The mobile @media rules for .info-tooltip were declared before the
default rules, so the default position: absolute / width: 280px won
the cascade. On narrow screens with .info-tooltip-left applied, the
tooltip anchored to the tiny info-icon wrapper with right: 20px and
its left edge fell off the viewport.

Move the mobile styles after the default rules so they override, and
include .info-tooltip-left in the mobile selector so both sides pin
to the viewport edges.