### PR TITLE
Add Nostr npub field to person credits

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -477,6 +477,19 @@ export function Editor() {
                           })}
                         />
                       </div>
+                      <div className="form-group">
+                        <label className="form-label">Nostr npub<InfoIcon text={FIELD_INFO.personNpub} /></label>
+                        <input
+                          type="text"
+                          className="form-input"
+                          placeholder="npub1..."
+                          value={person.npub || ''}
+                          onChange={e => dispatch({
+                            type: 'UPDATE_PERSON',
+                            payload: { index: personIndex, person: { ...person, npub: e.target.value } }
+                          })}
+                        />
+                      </div>
                     </div>
 
                     {/* Two-column layout: Roles (left) + Thumbnail Preview (right) */}
@@ -1153,6 +1166,19 @@ export function Editor() {
                                     onChange={e => dispatch({
                                       type: 'UPDATE_TRACK_PERSON',
                                       payload: { trackIndex: index, personIndex, person: { ...person, img: e.target.value } }
+                                    })}
+                                  />
+                                </div>
+                                <div className="form-group">
+                                  <label className="form-label">Nostr npub<InfoIcon text={FIELD_INFO.personNpub} /></label>
+                                  <input
+                                    type="text"
+                                    className="form-input"
+                                    placeholder="npub1..."
+                                    value={person.npub || ''}
+                                    onChange={e => dispatch({
+                                      type: 'UPDATE_TRACK_PERSON',
+                                      payload: { trackIndex: index, personIndex, person: { ...person, npub: e.target.value } }
                                     })}
                                   />
                                 </div>

--- a/src/data/fieldInfo.ts
+++ b/src/data/fieldInfo.ts
@@ -25,6 +25,7 @@ export const FIELD_INFO = {
   personName: "The person's name as it should appear in credits.",
   personHref: "Link to the person's website or social profile.",
   personImg: "Link to the person's profile picture.",
+  personNpub: "Nostr public key (npub) for this person. Apps can use it to link to their Nostr profile.",
   personGroup: "Category: music (performers), writing (songwriters), production (producers/engineers).",
   personRole: "Roles from the Podcasting 2.0 taxonomy. The first role is Primary and shown by apps that only display one role. Add multiple roles per person as needed.",
 

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -29,6 +29,7 @@ export interface Person {
   name: string;
   href?: string;
   img?: string;
+  npub?: string;
   roles: PersonRole[];
 }
 
@@ -378,6 +379,7 @@ export const createEmptyPerson = (): Person => ({
   name: '',
   href: '',
   img: '',
+  npub: '',
   roles: [createEmptyPersonRole()]
 });
 

--- a/src/utils/xmlGenerator.test.ts
+++ b/src/utils/xmlGenerator.test.ts
@@ -187,3 +187,72 @@ describe('OP3 round-trip', () => {
     expect(parsed.tracks[0].enclosureUrl).not.toContain('op3.dev');
   });
 });
+
+describe('Person npub attribute', () => {
+  const sampleNpub = 'npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s';
+
+  it('emits npub attribute on podcast:person when set', () => {
+    const album = createEmptyAlbum();
+    album.title = 'Test Album';
+    album.author = 'Test Artist';
+    album.description = 'Test description';
+    album.persons = [
+      {
+        name: 'Alice',
+        href: 'https://example.com/alice',
+        img: 'https://example.com/alice.jpg',
+        npub: sampleNpub,
+        roles: [{ group: 'music', role: 'vocalist' }]
+      }
+    ];
+
+    const xml = generateRssFeed(album);
+
+    expect(xml).toContain(`npub="${sampleNpub}"`);
+    expect(xml).toContain('<podcast:person');
+    expect(xml).toContain('>Alice</podcast:person>');
+  });
+
+  it('omits npub attribute when not set', () => {
+    const album = createEmptyAlbum();
+    album.title = 'Test Album';
+    album.author = 'Test Artist';
+    album.description = 'Test description';
+    album.persons = [
+      {
+        name: 'Bob',
+        href: 'https://example.com/bob',
+        roles: [{ group: 'music', role: 'guitarist' }]
+      }
+    ];
+
+    const xml = generateRssFeed(album);
+
+    expect(xml).toContain('>Bob</podcast:person>');
+    expect(xml).not.toContain('npub=');
+  });
+
+  it('roundtrip preserves npub through generate → parse', () => {
+    const album = createEmptyAlbum();
+    album.title = 'Roundtrip Album';
+    album.author = 'Test Artist';
+    album.description = 'Test description';
+    album.persons = [
+      {
+        name: 'Carol',
+        href: 'https://example.com/carol',
+        img: '',
+        npub: sampleNpub,
+        roles: [{ group: 'music', role: 'drummer' }]
+      }
+    ];
+
+    const xml = generateRssFeed(album);
+    const parsed = parseRssFeed(xml);
+
+    expect(parsed.persons).toHaveLength(1);
+    expect(parsed.persons[0].name).toBe('Carol');
+    expect(parsed.persons[0].npub).toBe(sampleNpub);
+    expect(parsed.persons[0].roles).toEqual([{ group: 'music', role: 'drummer' }]);
+  });
+});

--- a/src/utils/xmlGenerator.ts
+++ b/src/utils/xmlGenerator.ts
@@ -175,6 +175,7 @@ const generatePersonXml = (person: Person, level: number): string => {
     const attrs: string[] = [];
     if (person.href) attrs.push(`href="${escapeXml(person.href)}"`);
     if (person.img) attrs.push(`img="${escapeXml(person.img)}"`);
+    if (person.npub) attrs.push(`npub="${escapeXml(person.npub)}"`);
     attrs.push(`group="${escapeXml(role.group)}"`);
     attrs.push(`role="${escapeXml(role.role)}"`);
     return `${indent(level)}<podcast:person ${attrs.join(' ')}>${escapeXml(person.name)}</podcast:person>`;

--- a/src/utils/xmlParser.test.ts
+++ b/src/utils/xmlParser.test.ts
@@ -77,3 +77,64 @@ describe('OP3 prefix detection and stripping', () => {
     expect(album.tracks[0].enclosureUrl).toBe('https://example.com/track1.mp3');
   });
 });
+
+// Helper to build RSS XML with raw channel-level podcast:person tags
+function buildRssWithPersonTags(personTags: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:podcast="https://podcastindex.org/namespace/1.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <itunes:author>Test Artist</itunes:author>
+    <description>A test feed</description>
+    <language>en</language>
+    <podcast:medium>music</podcast:medium>
+    ${personTags}
+    <item>
+      <title>Track 1</title>
+      <guid isPermaLink="false">track-guid-1</guid>
+      <enclosure url="https://example.com/track1.mp3" length="1234" type="audio/mpeg"/>
+      <itunes:duration>03:45</itunes:duration>
+    </item>
+  </channel>
+</rss>`;
+}
+
+describe('Person tag merging with npub', () => {
+  const npubA = 'npub1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const npubB = 'npub1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  it('keeps same-name persons with different npubs as distinct entries', () => {
+    const tags = `
+      <podcast:person href="https://example.com" img="https://example.com/p.jpg" npub="${npubA}" group="music" role="vocalist">Alex</podcast:person>
+      <podcast:person href="https://example.com" img="https://example.com/p.jpg" npub="${npubB}" group="music" role="vocalist">Alex</podcast:person>
+    `;
+    const album = parseRssFeed(buildRssWithPersonTags(tags));
+
+    expect(album.persons).toHaveLength(2);
+    const npubs = album.persons.map(p => p.npub).sort();
+    expect(npubs).toEqual([npubA, npubB].sort());
+  });
+
+  it('merges same-name + same-npub tags with different roles into one person', () => {
+    const tags = `
+      <podcast:person npub="${npubA}" group="music" role="vocalist">Alex</podcast:person>
+      <podcast:person npub="${npubA}" group="music" role="guitarist">Alex</podcast:person>
+    `;
+    const album = parseRssFeed(buildRssWithPersonTags(tags));
+
+    expect(album.persons).toHaveLength(1);
+    expect(album.persons[0].npub).toBe(npubA);
+    expect(album.persons[0].roles).toHaveLength(2);
+    expect(album.persons[0].roles.map(r => r.role).sort()).toEqual(['guitarist', 'vocalist']);
+  });
+
+  it('leaves npub undefined when attribute is absent', () => {
+    const tags = `
+      <podcast:person group="music" role="vocalist">Alex</podcast:person>
+    `;
+    const album = parseRssFeed(buildRssWithPersonTags(tags));
+
+    expect(album.persons).toHaveLength(1);
+    expect(album.persons[0].npub).toBeUndefined();
+  });
+});

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -246,6 +246,7 @@ interface ParsedPersonTag {
   name: string;
   href?: string;
   img?: string;
+  npub?: string;
   group: PersonGroup;
   role: string;
 }
@@ -258,6 +259,7 @@ function parsePersonTag(node: unknown): ParsedPersonTag | null {
     name: getText(node),
     href: getAttr(node, 'href') || undefined,
     img: getAttr(node, 'img') || undefined,
+    npub: getAttr(node, 'npub') || undefined,
     group: (getAttr(node, 'group') || 'music') as PersonGroup,
     role: getAttr(node, 'role') || 'band'
   };
@@ -268,8 +270,8 @@ function mergePersonTags(tags: ParsedPersonTag[]): Person[] {
   const personMap = new Map<string, Person>();
 
   for (const tag of tags) {
-    // Create a key based on name + href + img to group same person
-    const key = `${tag.name}|${tag.href || ''}|${tag.img || ''}`;
+    // Create a key based on name + href + img + npub to group same person
+    const key = `${tag.name}|${tag.href || ''}|${tag.img || ''}|${tag.npub || ''}`;
 
     if (personMap.has(key)) {
       // Add role to existing person
@@ -286,6 +288,7 @@ function mergePersonTags(tags: ParsedPersonTag[]): Person[] {
         name: tag.name,
         href: tag.href,
         img: tag.img,
+        npub: tag.npub,
         roles: [{ group: tag.group, role: tag.role }]
       });
     }


### PR DESCRIPTION
Stores the npub as an optional attribute on <podcast:person> tags,
parsed back on import and included in the merge key so two people
with the same name but different npubs remain distinct.