### PR TITLE
Add drops.basspistol.org to Nostr Music relay list

### DIFF
--- a/src/utils/nostrRelay.ts
+++ b/src/utils/nostrRelay.ts
@@ -10,6 +10,14 @@ export const DEFAULT_RELAYS = [
   // 'wss://relay.nostr.band' // Temporarily disabled - unreachable
 ];
 
+// Relays for Nostr Music publishing (kinds 36787/34139) and their NIP-09 deletions.
+// drops.basspistol.org is a public relay that only accepts music kinds, so it
+// lives here rather than in DEFAULT_RELAYS (which carries kind 0/30054/1063/etc).
+export const MUSIC_RELAYS = [
+  ...DEFAULT_RELAYS,
+  'wss://drops.basspistol.org',
+];
+
 /**
  * Connect to a relay with timeout (single attempt)
  */

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -5,6 +5,7 @@ import { parseRssFeed } from './xmlParser';
 import { formatReleasedDate } from './dateUtils';
 import {
   DEFAULT_RELAYS,
+  MUSIC_RELAYS,
   connectRelay,
   collectEvents,
   publishEventToRelays
@@ -13,7 +14,7 @@ import { getSigner, hasSigner } from './nostrSigner';
 import { parseNostrMusicEvent } from './nostrMusicConverter';
 
 // Re-export for backward compatibility
-export { DEFAULT_RELAYS };
+export { DEFAULT_RELAYS, MUSIC_RELAYS };
 
 // Re-export Blossom functions from dedicated module
 export { uploadToBlossom } from './blossom';
@@ -646,7 +647,7 @@ export interface PublishProgress {
 // Publish album tracks as Nostr Music events (kind 36787) + playlist (kind 34139)
 export async function publishNostrMusicTracks(
   album: Album,
-  relays = DEFAULT_RELAYS,
+  relays = MUSIC_RELAYS,
   onProgress?: (progress: PublishProgress) => void
 ): Promise<{ success: boolean; message: string; publishedCount: number; playlistPublished: boolean }> {
   if (!hasSigner()) {
@@ -739,7 +740,7 @@ export async function publishNostrMusicTracks(
 // Delete (unpublish) Nostr Music events for an album via NIP-09
 export async function deleteNostrMusicTracks(
   album: Album,
-  relays = DEFAULT_RELAYS
+  relays = MUSIC_RELAYS
 ): Promise<{ success: boolean; message: string }> {
   if (!hasSigner()) {
     return { success: false, message: 'Not logged in' };

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -382,7 +382,7 @@ export function groupTracksByAlbum(tracks: NostrMusicTrackInfo[]): NostrMusicAlb
 
 // Fetch music track events (kind 36787) for logged-in user
 export async function fetchNostrMusicTracks(
-  relays = DEFAULT_RELAYS
+  relays = MUSIC_RELAYS
 ): Promise<{ success: boolean; tracks: NostrMusicTrackInfo[]; message: string }> {
   if (!hasSigner()) {
     return { success: false, tracks: [], message: 'Not logged in' };


### PR DESCRIPTION
drops.basspistol.org is a public relay that only accepts music kinds,
so it goes in a new MUSIC_RELAYS list used by publishNostrMusicTracks
and deleteNostrMusicTracks rather than DEFAULT_RELAYS (which also
carries kind 0/30054/1063 events those relays would reject).