### PR TITLE
Add Nostr Music feed type with spec-only editor fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ The Save modal (`src/components/modals/SaveModal.tsx`) offers nine destinations.
 | Host on MSP | Generated RSS XML | Vercel Blob (`feeds/{feedId}.xml`) | Yes — `https://msp.podtards.com/api/hosted/{feedId}` |
 | Send Podping | Feed-update notification | Hive blockchain (via MSP hivepinger) | Indirectly — Podcast Index re-crawls the feed URL |
 | Save RSS feed to Nostr | Full RSS XML embedded in a kind 30054 event | Nostr relays only | No — only MSP reads kind 30054 (cross-device sync) |
-| Publish to Nostr Music | Per-track events (kind 36787) + playlist event (kind 34139) | Nostr relays | No — Nostr-native music clients only (Wavlake, Fountain, etc.). Audio files must already be hosted elsewhere; the events just reference enclosure URLs |
+| Publish to Nostr Music | Per-track events (kind 36787). Playlist event (kind 34139) is off by default — toggle the "Also publish a kind 34139 playlist" checkbox in SaveModal to include it. Kind 34139 is non-standard (not in the kind 36787 NIP) but some clients use it to display tracks as an album. | Nostr relays | No — Nostr-native music clients only (Wavlake, Fountain, etc.). Audio files must already be hosted elsewhere; the events just reference enclosure URLs |
 | Publish RSS feed to a Blossom server | Generated RSS XML | Blossom server (content-addressed) + kind 1063 NIP-94 pointer event on Nostr | Yes — `${origin}/api/feed/{npub}/{podcastGuid}.xml` resolves the pointer and 302s to the latest Blossom URL |
 | Publish RSS feed to nsite (experimental) | Generated RSS XML | Blossom server + NIP-5A site manifest (kind 35128) | Yes — via any nsite gateway URL |
 

--- a/src/App.css
+++ b/src/App.css
@@ -375,6 +375,13 @@ body {
   display: none;
 }
 
+.section-subtitle {
+  margin: 0 0 16px 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
 /* Form Fields */
 .form-grid {
   display: grid;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import type { FeedType } from './store/feedStore.tsx';
 import { NostrProvider, useNostr } from './store/nostrStore.tsx';
 import { ThemeProvider, useTheme } from './store/themeStore.tsx';
 import { parseRssFeed, isPublisherFeed, isVideoFeed, parsePublisherRssFeed } from './utils/xmlParser';
-import { createEmptyAlbum, createEmptyPublisherFeed, createEmptyVideoAlbum } from './types/feed';
+import { createEmptyAlbum, createEmptyPublisherFeed, createEmptyVideoAlbum, createEmptyNostrMusicAlbum } from './types/feed';
 import { pendingHostedStorage } from './utils/storage';
 import { generateTestAlbum } from './utils/testData';
 import { NostrLoginButton } from './components/NostrLoginButton';
@@ -114,6 +114,8 @@ function AppContent() {
       dispatch({ type: 'SET_PUBLISHER_FEED', payload: createEmptyPublisherFeed() });
     } else if (pendingNewFeedType === 'video') {
       dispatch({ type: 'SET_VIDEO_FEED', payload: createEmptyVideoAlbum() });
+    } else if (pendingNewFeedType === 'nostrMusic') {
+      dispatch({ type: 'SET_NOSTR_MUSIC_FEED', payload: createEmptyNostrMusicAlbum() });
     } else {
       dispatch({ type: 'SET_ALBUM', payload: createEmptyAlbum() });
     }
@@ -156,6 +158,10 @@ function AppContent() {
     if (feedType === 'publisher' && !state.publisherFeed) {
       dispatch({ type: 'CREATE_NEW_PUBLISHER_FEED' });
     }
+    // If switching to Nostr Music and no Nostr Music feed exists, create one
+    if (feedType === 'nostrMusic' && !state.nostrMusicFeed) {
+      dispatch({ type: 'CREATE_NEW_NOSTR_MUSIC_FEED' });
+    }
   };
 
   return (
@@ -176,6 +182,7 @@ function AppContent() {
               <option value="album">Album</option>
               <option value="video">Video</option>
               <option value="publisher">Publisher</option>
+              <option value="nostrMusic">Nostr Music</option>
             </select>
           </div>
           <div className="header-actions">
@@ -268,12 +275,12 @@ function AppContent() {
             </div>
           </div>
         </header>
-        {state.feedType === 'publisher' ? <PublisherEditor /> : <Editor key={`${state.feedType}-${state.album?.podcastGuid}-${state.videoFeed?.podcastGuid}`} />}
+        {state.feedType === 'publisher' ? <PublisherEditor /> : <Editor key={`${state.feedType}-${state.album?.podcastGuid}-${state.videoFeed?.podcastGuid}-${state.nostrMusicFeed?.podcastGuid}`} />}
         <div className="bottom-toolbar">
           <button
             className="bottom-toolbar-btn"
             onClick={() => handleNew(state.feedType)}
-            title={`New ${state.feedType === 'publisher' ? 'Publisher' : state.feedType === 'video' ? 'Video Feed' : 'Album'}`}
+            title={`New ${state.feedType === 'publisher' ? 'Publisher' : state.feedType === 'video' ? 'Video Feed' : state.feedType === 'nostrMusic' ? 'Nostr Music Feed' : 'Album'}`}
           >
             <span className="bottom-toolbar-icon">📂</span>
             <span className="bottom-toolbar-label">New</span>
@@ -334,7 +341,7 @@ function AppContent() {
       {showSaveModal && (
         <SaveModal
           onClose={() => setShowSaveModal(false)}
-          album={state.feedType === 'video' && state.videoFeed ? state.videoFeed : state.album}
+          album={state.feedType === 'video' && state.videoFeed ? state.videoFeed : state.feedType === 'nostrMusic' && state.nostrMusicFeed ? state.nostrMusicFeed : state.album}
           publisherFeed={state.publisherFeed}
           feedType={state.feedType}
           isDirty={state.isDirty}
@@ -346,7 +353,7 @@ function AppContent() {
       {showPreviewModal && (
         <PreviewModal
           onClose={() => setShowPreviewModal(false)}
-          album={state.feedType === 'video' && state.videoFeed ? state.videoFeed : state.album}
+          album={state.feedType === 'video' && state.videoFeed ? state.videoFeed : state.feedType === 'nostrMusic' && state.nostrMusicFeed ? state.nostrMusicFeed : state.album}
           publisherFeed={state.publisherFeed}
           feedType={state.feedType}
         />
@@ -360,14 +367,18 @@ function AppContent() {
               ? state.publisherFeed.podcastGuid
               : state.feedType === 'video' && state.videoFeed
                 ? state.videoFeed.podcastGuid
-                : state.album.podcastGuid
+                : state.feedType === 'nostrMusic' && state.nostrMusicFeed
+                  ? state.nostrMusicFeed.podcastGuid
+                  : state.album.podcastGuid
           }
           medium={
             state.feedType === 'publisher' && state.publisherFeed
               ? state.publisherFeed.medium
               : state.feedType === 'video' && state.videoFeed
                 ? state.videoFeed.medium
-                : state.album.medium
+                : state.feedType === 'nostrMusic' && state.nostrMusicFeed
+                  ? state.nostrMusicFeed.medium
+                  : state.album.medium
           }
         />
       )}
@@ -380,14 +391,18 @@ function AppContent() {
               ? state.publisherFeed.podcastGuid
               : state.feedType === 'video' && state.videoFeed
                 ? state.videoFeed.podcastGuid
-                : state.album.podcastGuid
+                : state.feedType === 'nostrMusic' && state.nostrMusicFeed
+                  ? state.nostrMusicFeed.podcastGuid
+                  : state.album.podcastGuid
           }
           medium={
             state.feedType === 'publisher' && state.publisherFeed
               ? state.publisherFeed.medium
               : state.feedType === 'video' && state.videoFeed
                 ? state.videoFeed.medium
-                : state.album.medium
+                : state.feedType === 'nostrMusic' && state.nostrMusicFeed
+                  ? state.nostrMusicFeed.medium
+                  : state.album.medium
           }
         />
       )}

--- a/src/components/ArtworkFields.tsx
+++ b/src/components/ArtworkFields.tsx
@@ -10,6 +10,8 @@ interface ArtworkFieldsProps {
   urlPlaceholder?: string;
   titlePlaceholder?: string;
   previewAlt?: string;
+  hideTitle?: boolean;
+  hideDescription?: boolean;
 }
 
 export function ArtworkFields({
@@ -20,7 +22,9 @@ export function ArtworkFields({
   urlLabel = 'Image URL',
   urlPlaceholder = 'https://example.com/image.jpg',
   titlePlaceholder = 'Image description',
-  previewAlt = 'Image preview'
+  previewAlt = 'Image preview',
+  hideTitle = false,
+  hideDescription = false
 }: ArtworkFieldsProps) {
   return (
     <div className="form-grid">
@@ -34,26 +38,30 @@ export function ArtworkFields({
           onChange={e => onUpdate('imageUrl', e.target.value)}
         />
       </div>
-      <div className="form-group">
-        <label className="form-label">Image Title<InfoIcon text={FIELD_INFO.imageTitle} /></label>
-        <input
-          type="text"
-          className="form-input"
-          placeholder={titlePlaceholder}
-          value={imageTitle || ''}
-          onChange={e => onUpdate('imageTitle', e.target.value)}
-        />
-      </div>
-      <div className="form-group">
-        <label className="form-label">Image Description<InfoIcon text={FIELD_INFO.imageDescription} /></label>
-        <input
-          type="text"
-          className="form-input"
-          placeholder="Optional description"
-          value={imageDescription || ''}
-          onChange={e => onUpdate('imageDescription', e.target.value)}
-        />
-      </div>
+      {!hideTitle && (
+        <div className="form-group">
+          <label className="form-label">Image Title<InfoIcon text={FIELD_INFO.imageTitle} /></label>
+          <input
+            type="text"
+            className="form-input"
+            placeholder={titlePlaceholder}
+            value={imageTitle || ''}
+            onChange={e => onUpdate('imageTitle', e.target.value)}
+          />
+        </div>
+      )}
+      {!hideDescription && (
+        <div className="form-group">
+          <label className="form-label">Image Description<InfoIcon text={FIELD_INFO.imageDescription} /></label>
+          <input
+            type="text"
+            className="form-input"
+            placeholder="Optional description"
+            value={imageDescription || ''}
+            onChange={e => onUpdate('imageDescription', e.target.value)}
+          />
+        </div>
+      )}
       {imageUrl && (
         <div className="form-group full-width">
           <img

--- a/src/components/ArtworkFields.tsx
+++ b/src/components/ArtworkFields.tsx
@@ -1,4 +1,4 @@
-import { FIELD_INFO } from '../data/fieldInfo';
+import { FIELD_INFO, fieldInfoFor } from '../data/fieldInfo';
 import { InfoIcon } from './InfoIcon';
 
 interface ArtworkFieldsProps {
@@ -12,6 +12,7 @@ interface ArtworkFieldsProps {
   previewAlt?: string;
   hideTitle?: boolean;
   hideDescription?: boolean;
+  feedType?: string;
 }
 
 export function ArtworkFields({
@@ -24,12 +25,13 @@ export function ArtworkFields({
   titlePlaceholder = 'Image description',
   previewAlt = 'Image preview',
   hideTitle = false,
-  hideDescription = false
+  hideDescription = false,
+  feedType
 }: ArtworkFieldsProps) {
   return (
     <div className="form-grid">
       <div className="form-group">
-        <label className="form-label">{urlLabel} <span className="required">*</span><InfoIcon text={FIELD_INFO.imageUrl} /></label>
+        <label className="form-label">{urlLabel} <span className="required">*</span><InfoIcon text={fieldInfoFor('imageUrl', feedType)} /></label>
         <input
           type="url"
           className="form-input"

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -3,7 +3,7 @@ import { useFeed } from '../../store/feedStore';
 import { useNostr } from '../../store/nostrStore';
 import { LANGUAGES, PERSON_GROUPS, PERSON_ROLES, createEmptyPersonRole, createEmptyTrack, isVideoMedium, isCommunitySupport, createSupportRecipients, hasUserRecipients } from '../../types/feed';
 import type { PersonGroup } from '../../types/feed';
-import { FIELD_INFO } from '../../data/fieldInfo';
+import { FIELD_INFO, fieldInfoFor } from '../../data/fieldInfo';
 import { detectAddressType } from '../../utils/addressUtils';
 import { getMediaDuration, secondsToHHMMSS, formatDuration } from '../../utils/audioUtils';
 import { getVideoMimeType } from '../../utils/videoUtils';
@@ -262,10 +262,13 @@ export function Editor() {
       <div className="main-content">
         <div className="editor-panel">
           {/* Album/Video/Nostr Music Info Section */}
-          <Section title={isNostrMusic ? "Nostr Music Info" : isVideo ? "Video Info" : "Album Info"} icon={isNostrMusic ? "🎶" : isVideo ? "🎬" : "💿"}>
+          <Section title={isNostrMusic ? "Playlist" : isVideo ? "Video Info" : "Album Info"} icon={isNostrMusic ? "🎵" : isVideo ? "🎬" : "💿"}>
+            {isNostrMusic && (
+              <p className="section-subtitle">Published as a Nostr playlist event (kind 34139).</p>
+            )}
             <div className="form-grid">
               <div className="form-group">
-                <label className="form-label">Artist/Band <span className="required">*</span><InfoIcon text={FIELD_INFO.author} /></label>
+                <label className="form-label">Artist/Band <span className="required">*</span><InfoIcon text={fieldInfoFor('author', state.feedType)} /></label>
                 <input
                   type="text"
                   className="form-input"
@@ -335,6 +338,21 @@ export function Editor() {
                   )}
                 </div>
               )}
+              {isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Genre Tags<InfoIcon text={FIELD_INFO.genreTags} /></label>
+                  <input
+                    type="text"
+                    className="form-input"
+                    placeholder="rock, electronic, ambient"
+                    value={album.categories.join(', ')}
+                    onChange={e => dispatch({
+                      type: 'UPDATE_ALBUM',
+                      payload: { categories: e.target.value.split(',').map(s => s.trim()).filter(Boolean) }
+                    })}
+                  />
+                </div>
+              )}
               <div className="form-group full-width">
                 <label className="form-label">Description <span className="required">*</span><InfoIcon text={FIELD_INFO.description} /></label>
                 <textarea
@@ -344,31 +362,33 @@ export function Editor() {
                   onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { description: e.target.value } })}
                 />
               </div>
-              <div className="form-group">
-                <label className="form-label">Podcast GUID <span className="required">*</span><InfoIcon text={FIELD_INFO.podcastGuid} /></label>
-                <div style={{ display: 'flex', gap: '8px' }}>
-                  <input
-                    type="text"
-                    className="form-input"
-                    placeholder="Auto-generated UUID"
-                    value={album.podcastGuid || ''}
-                    onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { podcastGuid: e.target.value } })}
-                    style={{ flex: 1 }}
-                  />
-                  <button
-                    type="button"
-                    className="btn btn-secondary btn-small"
-                    title="Generate new GUID"
-                    onClick={() => {
-                      if (confirm('Generate a new GUID? This will create a new feed identity. Only do this if you are using this feed as a template for a new album.')) {
-                        dispatch({ type: 'UPDATE_ALBUM', payload: { podcastGuid: crypto.randomUUID() } });
-                      }
-                    }}
-                  >
-                    New
-                  </button>
+              {!isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Podcast GUID <span className="required">*</span><InfoIcon text={FIELD_INFO.podcastGuid} /></label>
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <input
+                      type="text"
+                      className="form-input"
+                      placeholder="Auto-generated UUID"
+                      value={album.podcastGuid || ''}
+                      onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { podcastGuid: e.target.value } })}
+                      style={{ flex: 1 }}
+                    />
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-small"
+                      title="Generate new GUID"
+                      onClick={() => {
+                        if (confirm('Generate a new GUID? This will create a new feed identity. Only do this if you are using this feed as a template for a new album.')) {
+                          dispatch({ type: 'UPDATE_ALBUM', payload: { podcastGuid: crypto.randomUUID() } });
+                        }
+                      }}
+                    >
+                      New
+                    </button>
+                  </div>
                 </div>
-              </div>
+              )}
               {!isNostrMusic && (
                 <div className="form-group">
                   <label className="form-label">Keywords<InfoIcon text={FIELD_INFO.keywords} /></label>
@@ -432,26 +452,44 @@ export function Editor() {
                 </div>
               )}
             </div>
+            {isNostrMusic && (
+              <ArtworkFields
+                imageUrl={album.imageUrl}
+                imageTitle={album.imageTitle}
+                imageDescription={album.imageDescription}
+                onUpdate={(field, value) => dispatch({ type: 'UPDATE_ALBUM', payload: { [field]: value } })}
+                urlLabel="Cover Image URL"
+                urlPlaceholder="https://example.com/album-art.jpg"
+                previewAlt="Cover preview"
+                hideTitle
+                hideDescription
+                feedType={state.feedType}
+              />
+            )}
           </Section>
 
-          {/* Artwork Section */}
-          <Section title={isVideo ? "Video Artwork" : "Album Artwork"} icon={isVideo ? "🎬" : "🎨"}>
-            <ArtworkFields
-              imageUrl={album.imageUrl}
-              imageTitle={album.imageTitle}
-              imageDescription={album.imageDescription}
-              onUpdate={(field, value) => dispatch({ type: 'UPDATE_ALBUM', payload: { [field]: value } })}
-              urlLabel={isVideo ? "Video Art URL" : "Album Art URL"}
-              urlPlaceholder={isVideo ? "https://example.com/video-art.jpg" : "https://example.com/album-art.jpg"}
-              titlePlaceholder={isVideo ? "Video cover description" : "Album cover description"}
-              previewAlt={isVideo ? "Video preview" : "Album preview"}
-              hideTitle={isNostrMusic}
-              hideDescription={isNostrMusic}
-            />
-          </Section>
+          {/* Artwork Section (hidden in nostrMusic — folded into Playlist above) */}
+          {!isNostrMusic && (
+            <Section title={isVideo ? "Video Artwork" : "Album Artwork"} icon={isVideo ? "🎬" : "🎨"}>
+              <ArtworkFields
+                imageUrl={album.imageUrl}
+                imageTitle={album.imageTitle}
+                imageDescription={album.imageDescription}
+                onUpdate={(field, value) => dispatch({ type: 'UPDATE_ALBUM', payload: { [field]: value } })}
+                urlLabel={isVideo ? "Video Art URL" : "Album Art URL"}
+                urlPlaceholder={isVideo ? "https://example.com/video-art.jpg" : "https://example.com/album-art.jpg"}
+                titlePlaceholder={isVideo ? "Video cover description" : "Album cover description"}
+                previewAlt={isVideo ? "Video preview" : "Album preview"}
+                feedType={state.feedType}
+              />
+            </Section>
+          )}
 
           {/* Credits Section */}
-          <Section title="Credits / Persons" icon="&#128100;">
+          <Section title={isNostrMusic ? "Credits" : "Credits / Persons"} icon="&#128100;">
+            {isNostrMusic && (
+              <p className="section-subtitle">Included in the content of each track event.</p>
+            )}
             <div className="repeatable-list">
               {album.persons.map((person, personIndex) => (
                 <div key={personIndex} className="repeatable-item">
@@ -500,7 +538,8 @@ export function Editor() {
 
                     {/* Two-column layout: Roles (left) + Thumbnail Preview (right) */}
                     <div className="person-preview-container" style={{ marginTop: '16px', display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
-                      {/* Left column: Roles section */}
+                      {/* Left column: Roles section (hidden in Nostr Music — roles aren't part of the kind 36787 event) */}
+                    {!isNostrMusic && (
                     <div className="person-roles-section" style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
                         <label className="form-label" style={{ margin: 0 }}>Roles<InfoIcon text={FIELD_INFO.personRole} /></label>
@@ -580,6 +619,7 @@ export function Editor() {
                         + Add Role
                       </button>
                     </div>
+                    )}
                       {/* Right column: Thumbnail preview */}
                       <div className="person-thumbnail-preview" style={{
                         width: '140px',
@@ -653,7 +693,10 @@ export function Editor() {
           </Section>
 
           {/* Value Block Section */}
-          <Section title="Value Block (Lightning)" icon="&#9889;">
+          <Section title={isNostrMusic ? "Zap Splits" : "Value Block (Lightning)"} icon="&#9889;">
+            {isNostrMusic && (
+              <p className="section-subtitle">Applied to every track unless a track overrides them.</p>
+            )}
             <RecipientsList
               recipients={album.value.recipients}
               onUpdate={(index, recipient) => dispatch({
@@ -750,6 +793,9 @@ export function Editor() {
 
           {/* Tracks/Videos Section */}
           <Section title={isNostrMusic ? "Tracks" : isVideo ? "Videos" : "Tracks"} icon={isNostrMusic ? "🎶" : isVideo ? "🎬" : "🎵"}>
+            {isNostrMusic && (
+              <p className="section-subtitle">Each track is published as a separate Nostr track event (kind 36787).</p>
+            )}
             {album.tracks.length > 0 && (
               <div style={{ marginBottom: '12px', textAlign: 'right' }}>
                 <button
@@ -801,11 +847,11 @@ export function Editor() {
                       />
                     </div>
                     <div className="form-group">
-                      <label className="form-label">{isVideo ? 'Video URL' : 'MP3 URL'} <span className="required">*</span><InfoIcon text={FIELD_INFO.enclosureUrl} /></label>
+                      <label className="form-label">{isVideo ? 'Video URL' : isNostrMusic ? 'Audio URL' : 'MP3 URL'} <span className="required">*</span><InfoIcon text={fieldInfoFor('enclosureUrl', state.feedType)} /></label>
                       <input
                         type="url"
                         className="form-input"
-                        placeholder={isVideo ? "https://example.com/video.mp4" : "https://example.com/track.mp3"}
+                        placeholder={isVideo ? "https://example.com/video.mp4" : isNostrMusic ? "https://example.com/audio-file" : "https://example.com/track.mp3"}
                         value={track.enclosureUrl || ''}
                         onChange={e => {
                           const url = e.target.value;
@@ -944,7 +990,7 @@ export function Editor() {
                       )}
                     </div>
                     <div className="form-group">
-                      <label className="form-label">Duration (HH:MM:SS) <span className="required">*</span><InfoIcon text={FIELD_INFO.trackDuration} /></label>
+                      <label className="form-label">Duration (HH:MM:SS) <span className="required">*</span><InfoIcon text={fieldInfoFor('trackDuration', state.feedType)} /></label>
                       <input
                         type="text"
                         className="form-input"
@@ -969,7 +1015,7 @@ export function Editor() {
                       />
                     </div>
                     <div className="form-group">
-                      <label className="form-label">Pub Date<InfoIcon text={FIELD_INFO.trackPubDate} /></label>
+                      <label className="form-label">{isNostrMusic ? 'Released' : 'Pub Date'}<InfoIcon text={fieldInfoFor('trackPubDate', state.feedType)} /></label>
                       <input
                         type="datetime-local"
                         className="form-input"
@@ -1079,6 +1125,66 @@ export function Editor() {
                         })}
                       />
                     </div>
+                    {isNostrMusic && (
+                      <>
+                        <div className="form-group">
+                          <label className="form-label">Music Video URL<InfoIcon text={FIELD_INFO.trackVideoUrl} /></label>
+                          <input
+                            type="url"
+                            className="form-input"
+                            placeholder="https://example.com/video.mp4"
+                            value={track.videoUrl || ''}
+                            onChange={e => dispatch({
+                              type: 'UPDATE_TRACK',
+                              payload: { index, track: { videoUrl: e.target.value } }
+                            })}
+                          />
+                        </div>
+                        <div className="form-group">
+                          <label className="form-label">Format<InfoIcon text={FIELD_INFO.trackFormat} /></label>
+                          <select
+                            className="form-select"
+                            value={track.format || ''}
+                            onChange={e => dispatch({
+                              type: 'UPDATE_TRACK',
+                              payload: { index, track: { format: e.target.value } }
+                            })}
+                          >
+                            <option value="">— not set —</option>
+                            <option value="mp3">mp3</option>
+                            <option value="flac">flac</option>
+                            <option value="m4a">m4a</option>
+                            <option value="ogg">ogg</option>
+                          </select>
+                        </div>
+                        <div className="form-group">
+                          <label className="form-label">Bitrate<InfoIcon text={FIELD_INFO.trackBitrate} /></label>
+                          <input
+                            type="text"
+                            className="form-input"
+                            placeholder="320kbps"
+                            value={track.bitrate || ''}
+                            onChange={e => dispatch({
+                              type: 'UPDATE_TRACK',
+                              payload: { index, track: { bitrate: e.target.value } }
+                            })}
+                          />
+                        </div>
+                        <div className="form-group">
+                          <label className="form-label">Sample Rate (Hz)<InfoIcon text={FIELD_INFO.trackSampleRate} /></label>
+                          <input
+                            type="text"
+                            className="form-input"
+                            placeholder="44100"
+                            value={track.sampleRate || ''}
+                            onChange={e => dispatch({
+                              type: 'UPDATE_TRACK',
+                              payload: { index, track: { sampleRate: e.target.value } }
+                            })}
+                          />
+                        </div>
+                      </>
+                    )}
                     {!isNostrMusic && (
                     <div className="form-group">
                       <label className="form-label">Lyrics URL<InfoIcon text={FIELD_INFO.transcriptUrl} /></label>
@@ -1185,7 +1291,8 @@ export function Editor() {
                                 </div>
                               </div>
 
-                              {/* Roles */}
+                              {/* Roles (hidden in Nostr Music — roles aren't part of kind 36787) */}
+                              {!isNostrMusic && (
                               <div style={{ marginTop: '12px' }}>
                                 <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
                                   <label className="form-label" style={{ margin: 0 }}>Roles<InfoIcon text={FIELD_INFO.personRole} /></label>
@@ -1258,6 +1365,7 @@ export function Editor() {
                                   + Add Role
                                 </button>
                               </div>
+                              )}
                             </div>
                             <div className="repeatable-item-actions">
                               <button

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -111,8 +111,13 @@ function Op3StatsLink({ podcastGuid }: { podcastGuid: string }) {
 export function Editor() {
   const { state, dispatch } = useFeed();
   const { state: nostrState } = useNostr();
-  // Get the active album based on feedType (album or videoFeed)
-  const album = state.feedType === 'video' && state.videoFeed ? state.videoFeed : state.album;
+  // Get the active album based on feedType (album, videoFeed, or nostrMusicFeed)
+  const album = state.feedType === 'video' && state.videoFeed
+    ? state.videoFeed
+    : state.feedType === 'nostrMusic' && state.nostrMusicFeed
+      ? state.nostrMusicFeed
+      : state.album;
+  const isNostrMusic = state.feedType === 'nostrMusic';
 
   // Simple collapse state - all tracks start expanded (empty object = nothing collapsed)
   // Editor remounts on album change (via key prop), so this always starts fresh
@@ -256,8 +261,8 @@ export function Editor() {
     <>
       <div className="main-content">
         <div className="editor-panel">
-          {/* Album/Video Info Section */}
-          <Section title={isVideo ? "Video Info" : "Album Info"} icon={isVideo ? "🎬" : "💿"}>
+          {/* Album/Video/Nostr Music Info Section */}
+          <Section title={isNostrMusic ? "Nostr Music Info" : isVideo ? "Video Info" : "Album Info"} icon={isNostrMusic ? "🎶" : isVideo ? "🎬" : "💿"}>
             <div className="form-grid">
               <div className="form-group">
                 <label className="form-label">Artist/Band <span className="required">*</span><InfoIcon text={FIELD_INFO.author} /></label>
@@ -270,7 +275,7 @@ export function Editor() {
                 />
               </div>
               <div className="form-group">
-                <label className="form-label">{isVideo ? 'Video Title' : 'Album Title'} <span className="required">*</span><InfoIcon text={FIELD_INFO.title} /></label>
+                <label className="form-label">{isNostrMusic ? 'Album Title' : isVideo ? 'Video Title' : 'Album Title'} <span className="required">*</span><InfoIcon text={FIELD_INFO.title} /></label>
                 <input
                   type="text"
                   className="form-input"
@@ -279,16 +284,18 @@ export function Editor() {
                   onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { title: e.target.value } })}
                 />
               </div>
-              <div className="form-group">
-                <label className="form-label">Website<InfoIcon text={FIELD_INFO.link} /></label>
-                <input
-                  type="url"
-                  className="form-input"
-                  placeholder="https://yourband.com"
-                  value={album.link || ''}
-                  onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { link: e.target.value } })}
-                />
-              </div>
+              {!isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Website<InfoIcon text={FIELD_INFO.link} /></label>
+                  <input
+                    type="url"
+                    className="form-input"
+                    placeholder="https://yourband.com"
+                    value={album.link || ''}
+                    onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { link: e.target.value } })}
+                  />
+                </div>
+              )}
               <div className="form-group">
                 <label className="form-label">Language <span className="required">*</span><InfoIcon text={FIELD_INFO.language} /></label>
                 <select
@@ -301,31 +308,33 @@ export function Editor() {
                   ))}
                 </select>
               </div>
-              <div className="form-group" style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', paddingTop: '28px', gap: '10px' }}>
-                <Toggle
-                  checked={album.explicit}
-                  onChange={val => dispatch({ type: 'UPDATE_ALBUM', payload: { explicit: val } })}
-                  label="Explicit Content"
-                  labelSuffix={<InfoIcon text={FIELD_INFO.explicit} />}
-                />
-                <Toggle
-                  checked={album.op3}
-                  onChange={val => dispatch({ type: 'UPDATE_ALBUM', payload: { op3: val } })}
-                  label={<>
-                    <a
-                      href="https://op3.dev/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      style={{ color: 'var(--accent-color)', textDecoration: 'underline' }}
-                      title="Learn more at op3.dev"
-                    >OP3</a> Analytics
-                  </>}
-                  labelSuffix={<InfoIcon text={FIELD_INFO.op3} />}
-                />
-                {album.op3 && album.podcastGuid && (
-                  <Op3StatsLink podcastGuid={album.podcastGuid} />
-                )}
-              </div>
+              {!isNostrMusic && (
+                <div className="form-group" style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', paddingTop: '28px', gap: '10px' }}>
+                  <Toggle
+                    checked={album.explicit}
+                    onChange={val => dispatch({ type: 'UPDATE_ALBUM', payload: { explicit: val } })}
+                    label="Explicit Content"
+                    labelSuffix={<InfoIcon text={FIELD_INFO.explicit} />}
+                  />
+                  <Toggle
+                    checked={album.op3}
+                    onChange={val => dispatch({ type: 'UPDATE_ALBUM', payload: { op3: val } })}
+                    label={<>
+                      <a
+                        href="https://op3.dev/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ color: 'var(--accent-color)', textDecoration: 'underline' }}
+                        title="Learn more at op3.dev"
+                      >OP3</a> Analytics
+                    </>}
+                    labelSuffix={<InfoIcon text={FIELD_INFO.op3} />}
+                  />
+                  {album.op3 && album.podcastGuid && (
+                    <Op3StatsLink podcastGuid={album.podcastGuid} />
+                  )}
+                </div>
+              )}
               <div className="form-group full-width">
                 <label className="form-label">Description <span className="required">*</span><InfoIcon text={FIELD_INFO.description} /></label>
                 <textarea
@@ -360,60 +369,68 @@ export function Editor() {
                   </button>
                 </div>
               </div>
-              <div className="form-group">
-                <label className="form-label">Keywords<InfoIcon text={FIELD_INFO.keywords} /></label>
-                <input
-                  type="text"
-                  className="form-input"
-                  placeholder="rock, indie, guitar, electronic"
-                  value={album.keywords || ''}
-                  onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { keywords: e.target.value } })}
-                />
-              </div>
-              <div className="form-group">
-                <label className="form-label">Owner Name<InfoIcon text={FIELD_INFO.ownerName} /></label>
-                <input
-                  type="text"
-                  className="form-input"
-                  placeholder="Your name or band name"
-                  value={album.ownerName || ''}
-                  onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { ownerName: e.target.value } })}
-                />
-              </div>
-              <div className="form-group">
-                <label className="form-label">Owner Email<InfoIcon text={FIELD_INFO.ownerEmail} /></label>
-                <input
-                  type="email"
-                  className="form-input"
-                  placeholder="contact@yourband.com"
-                  value={album.ownerEmail || ''}
-                  onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { ownerEmail: e.target.value } })}
-                />
-              </div>
-              <div className="form-group">
-                <label className="form-label">Artist npub<InfoIcon text={FIELD_INFO.artistNpub} /></label>
-                <div style={{ display: 'flex', gap: '8px' }}>
+              {!isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Keywords<InfoIcon text={FIELD_INFO.keywords} /></label>
                   <input
                     type="text"
                     className="form-input"
-                    placeholder="npub1..."
-                    value={album.artistNpub || ''}
-                    onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { artistNpub: e.target.value } })}
-                    style={{ flex: 1 }}
+                    placeholder="rock, indie, guitar, electronic"
+                    value={album.keywords || ''}
+                    onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { keywords: e.target.value } })}
                   />
-                  {nostrState.isLoggedIn && nostrState.user?.npub && (
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      onClick={() => dispatch({ type: 'UPDATE_ALBUM', payload: { artistNpub: nostrState.user!.npub } })}
-                      title="Use your logged-in Nostr npub"
-                      style={{ padding: '0 12px', fontSize: '0.8rem' }}
-                    >
-                      use mine
-                    </button>
-                  )}
                 </div>
-              </div>
+              )}
+              {!isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Owner Name<InfoIcon text={FIELD_INFO.ownerName} /></label>
+                  <input
+                    type="text"
+                    className="form-input"
+                    placeholder="Your name or band name"
+                    value={album.ownerName || ''}
+                    onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { ownerName: e.target.value } })}
+                  />
+                </div>
+              )}
+              {!isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Owner Email<InfoIcon text={FIELD_INFO.ownerEmail} /></label>
+                  <input
+                    type="email"
+                    className="form-input"
+                    placeholder="contact@yourband.com"
+                    value={album.ownerEmail || ''}
+                    onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { ownerEmail: e.target.value } })}
+                  />
+                </div>
+              )}
+              {!isNostrMusic && (
+                <div className="form-group">
+                  <label className="form-label">Artist npub<InfoIcon text={FIELD_INFO.artistNpub} /></label>
+                  <div style={{ display: 'flex', gap: '8px' }}>
+                    <input
+                      type="text"
+                      className="form-input"
+                      placeholder="npub1..."
+                      value={album.artistNpub || ''}
+                      onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { artistNpub: e.target.value } })}
+                      style={{ flex: 1 }}
+                    />
+                    {nostrState.isLoggedIn && nostrState.user?.npub && (
+                      <button
+                        type="button"
+                        className="btn btn-secondary"
+                        onClick={() => dispatch({ type: 'UPDATE_ALBUM', payload: { artistNpub: nostrState.user!.npub } })}
+                        title="Use your logged-in Nostr npub"
+                        style={{ padding: '0 12px', fontSize: '0.8rem' }}
+                      >
+                        use mine
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
             </div>
           </Section>
 
@@ -428,6 +445,8 @@ export function Editor() {
               urlPlaceholder={isVideo ? "https://example.com/video-art.jpg" : "https://example.com/album-art.jpg"}
               titlePlaceholder={isVideo ? "Video cover description" : "Album cover description"}
               previewAlt={isVideo ? "Video preview" : "Album preview"}
+              hideTitle={isNostrMusic}
+              hideDescription={isNostrMusic}
             />
           </Section>
 
@@ -647,14 +666,17 @@ export function Editor() {
           </Section>
 
           {/* Funding Section */}
-          <Section title="Funding" icon="&#128176;">
-            <FundingFields
-              funding={album.funding}
-              onUpdate={funding => dispatch({ type: 'UPDATE_ALBUM', payload: { funding } })}
-            />
-          </Section>
+          {!isNostrMusic && (
+            <Section title="Funding" icon="&#128176;">
+              <FundingFields
+                funding={album.funding}
+                onUpdate={funding => dispatch({ type: 'UPDATE_ALBUM', payload: { funding } })}
+              />
+            </Section>
+          )}
 
           {/* Publisher Section */}
+          {!isNostrMusic && (
           <Section title="Publisher Feed (Advanced)" icon="&#127970;">
             <p style={{ color: 'var(--text-secondary)', marginBottom: '16px', fontSize: '14px' }}>
               Add this release to a publisher catalog by entering the publisher's feed URL (must be in Podcast Index).
@@ -724,9 +746,10 @@ export function Editor() {
               )}
             </div>
           </Section>
+          )}
 
           {/* Tracks/Videos Section */}
-          <Section title={isVideo ? "Videos" : "Tracks"} icon={isVideo ? "🎬" : "🎵"}>
+          <Section title={isNostrMusic ? "Tracks" : isVideo ? "Videos" : "Tracks"} icon={isNostrMusic ? "🎶" : isVideo ? "🎬" : "🎵"}>
             {album.tracks.length > 0 && (
               <div style={{ marginBottom: '12px', textAlign: 'right' }}>
                 <button
@@ -957,6 +980,7 @@ export function Editor() {
                         })}
                       />
                     </div>
+                    {!isNostrMusic && (
                     <div className="form-group">
                       <label className="form-label">{isVideo ? 'Video #' : 'Track #'} (Episode)<InfoIcon text={FIELD_INFO.trackEpisode} /></label>
                       <input
@@ -981,6 +1005,7 @@ export function Editor() {
                         }}
                       />
                     </div>
+                    )}
                     <div className="form-group full-width">
                       <div className="track-preview-container" style={{ display: 'flex', gap: '16px', alignItems: 'flex-start' }}>
                         {/* Left column: Description */}
@@ -1054,6 +1079,7 @@ export function Editor() {
                         })}
                       />
                     </div>
+                    {!isNostrMusic && (
                     <div className="form-group">
                       <label className="form-label">Lyrics URL<InfoIcon text={FIELD_INFO.transcriptUrl} /></label>
                       <input
@@ -1067,6 +1093,7 @@ export function Editor() {
                         })}
                       />
                     </div>
+                    )}
                     <div className="form-group">
                       <Toggle
                         checked={track.explicit}

--- a/src/components/modals/NewFeedChoiceModal.tsx
+++ b/src/components/modals/NewFeedChoiceModal.tsx
@@ -10,7 +10,10 @@ interface NewFeedChoiceModalProps {
 }
 
 const feedTypeLabel = (feedType: FeedType) =>
-  feedType === 'publisher' ? 'Publisher Feed' : feedType === 'video' ? 'Video Feed' : 'Album';
+  feedType === 'publisher' ? 'Publisher Feed'
+    : feedType === 'video' ? 'Video Feed'
+    : feedType === 'nostrMusic' ? 'Nostr Music Feed'
+    : 'Album';
 
 export function NewFeedChoiceModal({
   isOpen,

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -60,6 +60,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [progress, setProgress] = useState<PublishProgress | null>(null);
   const [blossomServer, setBlossomServer] = useState(DEFAULT_BLOSSOM_SERVER);
+  const [nostrMusicIncludePlaylist, setNostrMusicIncludePlaylist] = useState(false);
   const [feedUrl, setFeedUrl] = useState<string | null>(null);
   const [stableUrl, setStableUrl] = useState<string | null>(null);
   const [hostedInfo, setHostedInfo] = useState<HostedFeedInfo | null>(null);
@@ -343,7 +344,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
           }
           break;
         case 'nostrMusic':
-          const musicResult = await publishNostrMusicTracks(album, undefined, setProgress);
+          const musicResult = await publishNostrMusicTracks(album, undefined, setProgress, nostrMusicIncludePlaylist);
           setProgress(null);
           // Show error/warning if not all tracks published or playlist failed
           const allTracksPublished = musicResult.publishedCount === album.tracks.length;
@@ -671,9 +672,25 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
             </p>
           )}
           {mode === 'nostrMusic' && (
-            <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginTop: '16px' }}>
-              Publish tracks and playlist to Nostr (kinds 36787 + 34139). Compatible with Nostr music clients.
-            </p>
+            <div style={{ marginTop: '16px' }}>
+              <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '8px' }}>
+                Publish each track to Nostr as kind 36787. Compatible with Nostr music clients.
+              </p>
+              <label style={{ display: 'flex', alignItems: 'flex-start', gap: '8px', fontSize: '0.875rem', color: 'var(--text-secondary)', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={nostrMusicIncludePlaylist}
+                  onChange={e => setNostrMusicIncludePlaylist(e.target.checked)}
+                  style={{ marginTop: '3px' }}
+                />
+                <span>
+                  Also publish a kind 34139 playlist event for album grouping
+                  <span style={{ display: 'block', fontSize: '0.75rem', opacity: 0.8, marginTop: '2px' }}>
+                    Non-standard (not in the kind 36787 NIP). Some clients use it to display tracks as a single album.
+                  </span>
+                </span>
+              </label>
+            </div>
           )}
           {mode === 'blossom' && (
             <div style={{ marginTop: '16px' }}>
@@ -1285,7 +1302,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                 <li><strong>Host on MSP</strong> - Host your feed on MSP servers. Get a permanent URL for your RSS feed to use in any app.{isLoggedIn && ' You can link your Nostr identity to edit from any device without needing the token.'}</li>
                 <li><strong>Send Podping</strong> - Broadcast a feed-update notification via Podping/Hive. Indexers like Podcast Index watch Hive and re-crawl the feed when they see the ping.</li>
                 <li><strong>Save RSS feed to Nostr</strong> - Stores the entire RSS XML inside a Nostr event (kind 30054) on your relays. Personal cross-device backup tied to your Nostr key. Not readable by podcast apps.</li>
-                <li><strong>Publish to Nostr Music</strong> - Publishes each track (kind 36787) and the playlist (kind 34139) as Nostr events for Nostr-native music clients like Wavlake and Fountain. Audio files must already be hosted somewhere - these events just point to them. Not a podcast RSS feed.</li>
+                <li><strong>Publish to Nostr Music</strong> - Publishes each track as a Nostr kind 36787 event for Nostr-native music clients like Wavlake and Fountain. Optionally also publishes a kind 34139 playlist event (non-standard) for clients that use it to group tracks as an album. Audio files must already be hosted somewhere - these events just point to them. Not a podcast RSS feed.</li>
                 <li><strong>Publish RSS feed to a Blossom server</strong> - Uploads the RSS file to a Blossom server and registers a Nostr pointer (kind 1063) so MSP can serve a permanent URL. Subscribable in any podcast app.</li>
                 <li><strong>Publish RSS feed to nsite (experimental)</strong> - Uploads the RSS file to a Blossom server and publishes an nsite site manifest (NIP-5A). Reachable as a permanent web URL through any nsite gateway. Subscribable in podcast apps.</li>
               </ul>

--- a/src/data/fieldInfo.ts
+++ b/src/data/fieldInfo.ts
@@ -62,4 +62,30 @@ export const FIELD_INFO = {
   trackExplicit: "Mark if this specific track contains explicit content.",
   overridePersons: "Enable to set different credits for this track than the album level. Track-level persons replace album-level.",
   overrideValue: "Enable to set different payment splits for this track. Used for featuring guest artists or different producers per track.",
+
+  // Nostr Music (kind 36787) optional tags
+  genreTags: "Comma-separated genres. Each becomes a Nostr 't' tag on the playlist and every track event, alongside the mandatory 'music' tag.",
+  trackVideoUrl: "Optional music video URL. Published as the 'video' tag on kind 36787 — Nostr clients can play the video instead of the audio file.",
+  trackFormat: "Audio format (mp3, flac, m4a, ogg). Published as the 'format' tag.",
+  trackBitrate: "Audio bitrate, e.g. '320kbps'. Published as the 'bitrate' tag.",
+  trackSampleRate: "Sample rate in Hz, e.g. '44100'. Published as the 'sample_rate' tag.",
 };
+
+// Nostr Music mode tooltips — override copy for fields where the default text
+// references RSS tags, MP3/enclosure hosting, or "podcast apps" (kind 36787 + 34139
+// events live on Nostr relays, not in an RSS feed).
+export const FIELD_INFO_NOSTR_MUSIC: Partial<Record<keyof typeof FIELD_INFO, string>> = {
+  author: "The artist or band name.",
+  imageUrl: "Direct link to your album art image.",
+  enclosureUrl: "Direct link to the audio file. The file must already be hosted externally — Nostr Music references the URL only.",
+  trackDuration: "Total duration in HH:MM:SS format. Shown by Nostr music clients.",
+  trackPubDate: "Publication date/time for this track. Used for sort order in Nostr music clients.",
+};
+
+export function fieldInfoFor(key: keyof typeof FIELD_INFO, feedType?: string): string {
+  if (feedType === 'nostrMusic') {
+    const override = FIELD_INFO_NOSTR_MUSIC[key];
+    if (override) return override;
+  }
+  return FIELD_INFO[key];
+}

--- a/src/store/feedStore.tsx
+++ b/src/store/feedStore.tsx
@@ -2,8 +2,8 @@
 import { createContext, useContext, useReducer, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import type { Album, Track, Person, PersonRole, ValueRecipient, Funding, PublisherFeed, RemoteItem, FeedType } from '../types/feed';
-import { createEmptyAlbum, createEmptyTrack, createEmptyPerson, createEmptyPersonRole, createEmptyRecipient, createEmptyFunding, createEmptyPublisherFeed, createEmptyRemoteItem, createEmptyVideoAlbum, createSupportRecipients, isCommunitySupport, hasUserRecipients } from '../types/feed';
-import { albumStorage, videoStorage, publisherStorage, feedTypeStorage } from '../utils/storage';
+import { createEmptyAlbum, createEmptyTrack, createEmptyPerson, createEmptyPersonRole, createEmptyRecipient, createEmptyFunding, createEmptyPublisherFeed, createEmptyRemoteItem, createEmptyVideoAlbum, createEmptyNostrMusicAlbum, createSupportRecipients, isCommunitySupport, hasUserRecipients } from '../types/feed';
+import { albumStorage, videoStorage, publisherStorage, nostrMusicStorage, feedTypeStorage } from '../utils/storage';
 
 export type { FeedType };
 
@@ -52,13 +52,18 @@ export type FeedAction =
   // Video feed actions
   | { type: 'SET_VIDEO_FEED'; payload: Album }
   | { type: 'UPDATE_VIDEO_FEED'; payload: Partial<Album> }
-  | { type: 'CREATE_NEW_VIDEO_FEED' };
+  | { type: 'CREATE_NEW_VIDEO_FEED' }
+  // Nostr Music feed actions
+  | { type: 'SET_NOSTR_MUSIC_FEED'; payload: Album }
+  | { type: 'UPDATE_NOSTR_MUSIC_FEED'; payload: Partial<Album> }
+  | { type: 'CREATE_NEW_NOSTR_MUSIC_FEED' };
 
 // State interface
 interface FeedState {
   feedType: FeedType;
   album: Album;
   videoFeed: Album | null;
+  nostrMusicFeed: Album | null;
   publisherFeed: PublisherFeed | null;
   isDirty: boolean;
 }
@@ -69,14 +74,18 @@ const initialState: FeedState = {
   feedType: feedTypeStorage.load(),
   album: albumStorage.load() || createEmptyAlbum(),
   videoFeed: videoStorage.load() || null,
+  nostrMusicFeed: nostrMusicStorage.load() || null,
   publisherFeed: publisherStorage.load() || null,
   isDirty: false
 };
 
-// Helper to get the current active album (album or videoFeed based on feedType)
+// Helper to get the current active album (album, videoFeed, or nostrMusicFeed based on feedType)
 function getActiveAlbum(state: FeedState): Album {
   if (state.feedType === 'video' && state.videoFeed) {
     return state.videoFeed;
+  }
+  if (state.feedType === 'nostrMusic' && state.nostrMusicFeed) {
+    return state.nostrMusicFeed;
   }
   return state.album;
 }
@@ -85,6 +94,9 @@ function getActiveAlbum(state: FeedState): Album {
 function updateActiveFeed(state: FeedState, albumUpdate: Album): FeedState {
   if (state.feedType === 'video') {
     return { ...state, videoFeed: albumUpdate, isDirty: true };
+  }
+  if (state.feedType === 'nostrMusic') {
+    return { ...state, nostrMusicFeed: albumUpdate, isDirty: true };
   }
   return { ...state, album: albumUpdate, isDirty: true };
 }
@@ -601,6 +613,28 @@ function feedReducer(state: FeedState, action: FeedAction): FeedState {
         isDirty: true
       };
 
+    // Nostr Music feed actions
+    case 'SET_NOSTR_MUSIC_FEED':
+      feedTypeStorage.save('nostrMusic');
+      return { ...state, nostrMusicFeed: action.payload, feedType: 'nostrMusic', isDirty: false };
+
+    case 'UPDATE_NOSTR_MUSIC_FEED':
+      if (!state.nostrMusicFeed) return state;
+      return {
+        ...state,
+        nostrMusicFeed: { ...state.nostrMusicFeed, ...action.payload },
+        isDirty: true
+      };
+
+    case 'CREATE_NEW_NOSTR_MUSIC_FEED':
+      feedTypeStorage.save('nostrMusic');
+      return {
+        ...state,
+        nostrMusicFeed: createEmptyNostrMusicAlbum(),
+        feedType: 'nostrMusic',
+        isDirty: true
+      };
+
     default:
       return state;
   }
@@ -636,6 +670,13 @@ export function FeedProvider({ children }: { children: ReactNode }) {
       publisherStorage.save(state.publisherFeed);
     }
   }, [state.publisherFeed]);
+
+  // Auto-save Nostr Music feed to localStorage
+  useEffect(() => {
+    if (state.nostrMusicFeed) {
+      nostrMusicStorage.save(state.nostrMusicFeed);
+    }
+  }, [state.nostrMusicFeed]);
 
   return (
     <FeedContext.Provider value={{ state, dispatch }}>

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -123,6 +123,11 @@ export interface Track {
   persons: Person[];
   overrideValue: boolean;
   value?: ValueBlock;
+  // Nostr Music (NIP kind 36787) optional tags
+  videoUrl?: string;
+  format?: string;
+  bitrate?: string;
+  sampleRate?: string;
   unknownItemElements?: Record<string, unknown>;
 }
 

--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -1,7 +1,7 @@
 // MSP 2.0 - Feed Type Definitions (Demu Template Compatible)
 
 // Feed type enum
-export type FeedType = 'album' | 'video' | 'publisher';
+export type FeedType = 'album' | 'video' | 'publisher' | 'nostrMusic';
 
 // All person groups from Podcasting 2.0 taxonomy + custom 'music' group
 export type PersonGroup =
@@ -291,6 +291,47 @@ export const hasUserRecipients = (recipients: ValueRecipient[]): boolean =>
 
 // Default empty album
 export const createEmptyAlbum = (): Album => ({
+  title: '',
+  author: '',
+  artistNpub: '',
+  description: '',
+  link: '',
+  language: 'en',
+  generator: 'MSP 2.0 - Music Side Project Studio',
+  pubDate: new Date().toUTCString(),
+  lastBuildDate: new Date().toUTCString(),
+  podcastGuid: crypto.randomUUID(),
+  medium: 'music',
+  locked: false,
+  lockedOwner: '',
+  categories: [],
+  keywords: '',
+  explicit: false,
+  ownerName: '',
+  ownerEmail: '',
+  imageUrl: '',
+  imageTitle: '',
+  imageLink: '',
+  imageDescription: '',
+  bannerArtUrl: '',
+  managingEditor: '',
+  webMaster: '',
+  persons: [],
+  value: {
+    type: 'lightning',
+    method: 'keysend',
+    suggested: '0.000033333',
+    recipients: [createEmptyRecipient()]
+  },
+  funding: [],
+  op3: false,
+  tracks: [createEmptyTrack(1)]
+});
+
+// Default empty Nostr Music album
+// Reuses the Album shape but only fields relevant to the Nostr Music spec
+// (kind 36787 track events + kind 34139 playlist) will be surfaced in the Editor.
+export const createEmptyNostrMusicAlbum = (): Album => ({
   title: '',
   author: '',
   artistNpub: '',

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -457,12 +457,13 @@ export async function fetchNostrMusicTracks(
   }
 }
 
-// Convert persons array to Credits section string
+// Convert persons array to Credits section string — names only (roles aren't
+// part of kind 36787, so emitting "Name: role" would be misleading).
 function formatCreditsFromPersons(persons: Person[]): string {
   if (!persons || persons.length === 0) return '';
-  // For each person, list all their roles
   return persons
-    .map(p => `${p.name}: ${p.roles.map(r => r.role).join(', ')}`)
+    .map(p => p.name?.trim())
+    .filter((name): name is string => !!name)
     .join('\n');
 }
 
@@ -560,6 +561,20 @@ function createMusicTrackEvent(
     tags.push(['t', category.toLowerCase()]);
   }
 
+  // NIP kind 36787 optional technical tags
+  if (track.videoUrl?.trim()) {
+    tags.push(['video', track.videoUrl.trim()]);
+  }
+  if (track.format?.trim()) {
+    tags.push(['format', track.format.trim()]);
+  }
+  if (track.bitrate?.trim()) {
+    tags.push(['bitrate', track.bitrate.trim()]);
+  }
+  if (track.sampleRate?.trim()) {
+    tags.push(['sample_rate', track.sampleRate.trim()]);
+  }
+
   // Add zap tags from value recipients (track-level if overridden, else album-level)
   const valueBlock = track.overrideValue && track.value ? track.value : album.value;
   if (valueBlock && valueBlock.recipients) {
@@ -648,7 +663,8 @@ export interface PublishProgress {
 export async function publishNostrMusicTracks(
   album: Album,
   relays = MUSIC_RELAYS,
-  onProgress?: (progress: PublishProgress) => void
+  onProgress?: (progress: PublishProgress) => void,
+  includePlaylist = false
 ): Promise<{ success: boolean; message: string; publishedCount: number; playlistPublished: boolean }> {
   if (!hasSigner()) {
     return { success: false, message: 'Not logged in', publishedCount: 0, playlistPublished: false };
@@ -698,10 +714,11 @@ export async function publishNostrMusicTracks(
       return { success: false, message: 'Failed to publish any tracks', publishedCount: 0, playlistPublished: false };
     }
 
-    // Phase 2: Publish playlist (only if 2+ tracks - single track isn't a playlist)
+    // Phase 2: Publish kind 34139 playlist — opt-in only (not defined in the
+    // kind 36787 NIP, so default is tracks-only for spec compliance).
     let playlistPublished = false;
 
-    if (publishedTracks.length >= 2) {
+    if (includePlaylist && publishedTracks.length >= 2) {
       if (onProgress) {
         onProgress({ current: 1, total: 1, trackTitle: album.title || 'Playlist', phase: 'playlist' });
       }
@@ -717,7 +734,7 @@ export async function publishNostrMusicTracks(
 
     // Build appropriate message
     let message: string;
-    if (publishedTracks.length < 2) {
+    if (!includePlaylist || publishedTracks.length < 2) {
       message = `Published ${publishedCount} track(s) to Nostr`;
     } else if (playlistPublished) {
       message = `Published ${publishedCount} track(s) and playlist to Nostr`;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -7,6 +7,7 @@ export const STORAGE_KEYS = {
   ALBUM_DATA: 'msp2-album-data',
   VIDEO_DATA: 'msp2-video-data',
   PUBLISHER_DATA: 'msp2-publisher-data',
+  NOSTR_MUSIC_DATA: 'msp2-nostr-music-data',
   FEED_TYPE: 'msp2-feed-type',
   NOSTR_USER: 'msp2-nostr-user',
   HOSTED_PREFIX: 'msp2-hosted-',
@@ -125,6 +126,19 @@ export const videoStorage = {
   clear: (): boolean => removeItem(STORAGE_KEYS.VIDEO_DATA)
 };
 
+// Nostr Music feed storage operations
+export const nostrMusicStorage = {
+  load: (): Album | null => {
+    const album = getItem<Album>(STORAGE_KEYS.NOSTR_MUSIC_DATA);
+    if (album) {
+      return migrateAlbum(album);
+    }
+    return null;
+  },
+  save: (album: Album): boolean => setItem(STORAGE_KEYS.NOSTR_MUSIC_DATA, album),
+  clear: (): boolean => removeItem(STORAGE_KEYS.NOSTR_MUSIC_DATA)
+};
+
 // Publisher feed storage operations
 export const publisherStorage = {
   load: (): PublisherFeed | null => getItem<PublisherFeed>(STORAGE_KEYS.PUBLISHER_DATA),
@@ -136,7 +150,7 @@ export const publisherStorage = {
 export const feedTypeStorage = {
   load: (): FeedType => {
     const stored = getItem<FeedType>(STORAGE_KEYS.FEED_TYPE);
-    return stored && ['album', 'video', 'publisher'].includes(stored) ? stored : 'album';
+    return stored && ['album', 'video', 'publisher', 'nostrMusic'].includes(stored) ? stored : 'album';
   },
   save: (feedType: FeedType): boolean => setItem(STORAGE_KEYS.FEED_TYPE, feedType)
 };


### PR DESCRIPTION
Introduces a 4th feedType 'nostrMusic' alongside album/video/publisher.
The Editor reuses the Album layout but hides fields not in the Nostr
Music spec (kind 36787 + 34139): website, OP3, keywords, owner
name/email, artist npub, album-level explicit, funding, publisher
reference, track episode number, and lyrics URL. State is persisted
under msp2-nostr-music-data via a dedicated nostrMusicFeed slot so it
doesn't conflict with existing album/video data.

https://claude.ai/code/session_01JWVYUT5SiYwLWrahXadd3L