### PR TITLE
Validate audio file format from URL extension

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -5,7 +5,7 @@ import { LANGUAGES, PERSON_GROUPS, PERSON_ROLES, createEmptyPersonRole, createEm
 import type { PersonGroup } from '../../types/feed';
 import { FIELD_INFO } from '../../data/fieldInfo';
 import { detectAddressType } from '../../utils/addressUtils';
-import { getMediaDuration, secondsToHHMMSS, formatDuration } from '../../utils/audioUtils';
+import { getMediaDuration, secondsToHHMMSS, formatDuration, getAudioMimeType, isKnownAudioFormat } from '../../utils/audioUtils';
 import { getVideoMimeType } from '../../utils/videoUtils';
 import { isNaddrString, resolveNostrVideo } from '../../utils/nostrVideoConverter';
 import { InfoIcon } from '../InfoIcon';
@@ -803,11 +803,11 @@ export function Editor() {
                             type: 'UPDATE_TRACK',
                             payload: { index, track: { enclosureUrl: url } }
                           });
-                          // Auto-detect MIME type for video feeds
-                          if (isVideo && url) {
+                          if (url) {
+                            const mimeType = isVideo ? getVideoMimeType(url) : getAudioMimeType(url);
                             dispatch({
                               type: 'UPDATE_TRACK',
-                              payload: { index, track: { enclosureType: getVideoMimeType(url) } }
+                              payload: { index, track: { enclosureType: mimeType } }
                             });
                           }
                         }}
@@ -851,13 +851,11 @@ export function Editor() {
                               type: 'UPDATE_TRACK',
                               payload: { index, track: { enclosureUrl: url } }
                             });
-                            // Auto-detect MIME type for video feeds
-                            if (isVideo) {
-                              dispatch({
-                                type: 'UPDATE_TRACK',
-                                payload: { index, track: { enclosureType: getVideoMimeType(url) } }
-                              });
-                            }
+                            const mimeType = isVideo ? getVideoMimeType(url) : getAudioMimeType(url);
+                            dispatch({
+                              type: 'UPDATE_TRACK',
+                              payload: { index, track: { enclosureType: mimeType } }
+                            });
                             // Fetch duration using unified Media API (works for both audio and video)
                             if (isNewUrl || !track.duration) {
                               const duration = await getMediaDuration(url);
@@ -913,6 +911,11 @@ export function Editor() {
                       {isVideo && !resolvingNaddr[index] && !track.enclosureUrl && (
                         <div style={{ color: 'var(--text-secondary)', fontSize: '0.8em', marginTop: '4px', opacity: 0.7 }}>
                           Tip: Paste a Nostr naddr to auto-fill video details
+                        </div>
+                      )}
+                      {!isVideo && track.enclosureUrl && !isKnownAudioFormat(track.enclosureUrl) && (
+                        <div style={{ color: 'var(--warning, #b8860b)', fontSize: '0.85em', marginTop: '4px' }}>
+                          URL doesn't end with a recognized audio extension (mp3, flac, wav, m4a, aac, ogg, opus, aiff). Podcast apps may not play it.
                         </div>
                       )}
                       {track.enclosureUrl && (

--- a/src/data/fieldInfo.ts
+++ b/src/data/fieldInfo.ts
@@ -55,7 +55,7 @@ export const FIELD_INFO = {
   trackPubDate: "Publication date/time for this track. Used for sorting and display in podcast apps.",
   trackSeason: "Season number for grouping tracks (e.g., 1 for first album). Optional.",
   trackEpisode: "Episode number for this track. Defaults to track order if not set.",
-  enclosureUrl: "Direct link to the MP3 file. Ensure CORS policy allows access.",
+  enclosureUrl: "Direct link to the audio file. MP3 is preferred — smaller file size saves bandwidth for listeners. Other formats (flac, wav, m4a, aac, ogg, opus, aiff) are also supported. Ensure CORS policy allows access.",
   enclosureLength: "File size in MB. Important for podcast apps to show download size.",
   trackArtUrl: "Optional track-specific artwork. If empty, album art is used.",
   transcriptUrl: "Link to an SRT file with time-coded lyrics for display during playback.",

--- a/src/utils/audioUtils.test.ts
+++ b/src/utils/audioUtils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { getAudioMimeType, isKnownAudioFormat } from './audioUtils';
+
+describe('getAudioMimeType', () => {
+  it('detects mp3 as audio/mpeg', () => {
+    expect(getAudioMimeType('https://example.com/track.mp3')).toBe('audio/mpeg');
+  });
+
+  it('detects flac as audio/flac', () => {
+    expect(getAudioMimeType('https://example.com/track.flac')).toBe('audio/flac');
+  });
+
+  it('detects wav as audio/wav', () => {
+    expect(getAudioMimeType('https://example.com/track.wav')).toBe('audio/wav');
+  });
+
+  it('detects m4a as audio/x-m4a', () => {
+    expect(getAudioMimeType('https://example.com/track.m4a')).toBe('audio/x-m4a');
+  });
+
+  it('detects aac as audio/aac', () => {
+    expect(getAudioMimeType('https://example.com/track.aac')).toBe('audio/aac');
+  });
+
+  it('detects ogg as audio/ogg', () => {
+    expect(getAudioMimeType('https://example.com/track.ogg')).toBe('audio/ogg');
+  });
+
+  it('detects opus as audio/opus', () => {
+    expect(getAudioMimeType('https://example.com/track.opus')).toBe('audio/opus');
+  });
+
+  it('detects aiff as audio/aiff', () => {
+    expect(getAudioMimeType('https://example.com/track.aiff')).toBe('audio/aiff');
+  });
+
+  it('is case-insensitive', () => {
+    expect(getAudioMimeType('https://example.com/Track.MP3')).toBe('audio/mpeg');
+    expect(getAudioMimeType('https://example.com/Track.FLAC')).toBe('audio/flac');
+  });
+
+  it('ignores query strings and fragments', () => {
+    expect(getAudioMimeType('https://example.com/track.mp3?token=abc')).toBe('audio/mpeg');
+    expect(getAudioMimeType('https://example.com/track.flac#chapter1')).toBe('audio/flac');
+  });
+
+  it('falls back to audio/mpeg for unknown extensions', () => {
+    expect(getAudioMimeType('https://example.com/track.xyz')).toBe('audio/mpeg');
+    expect(getAudioMimeType('https://example.com/track')).toBe('audio/mpeg');
+  });
+});
+
+describe('isKnownAudioFormat', () => {
+  it('accepts common audio extensions', () => {
+    expect(isKnownAudioFormat('https://example.com/a.mp3')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.flac')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.wav')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.m4a')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.aac')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.ogg')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.opus')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.aiff')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.aif')).toBe(true);
+  });
+
+  it('rejects non-audio extensions', () => {
+    expect(isKnownAudioFormat('https://example.com/a.mp4')).toBe(false);
+    expect(isKnownAudioFormat('https://example.com/a.pdf')).toBe(false);
+    expect(isKnownAudioFormat('https://example.com/a')).toBe(false);
+  });
+
+  it('handles query strings and fragments', () => {
+    expect(isKnownAudioFormat('https://example.com/a.mp3?x=1')).toBe(true);
+    expect(isKnownAudioFormat('https://example.com/a.mp4?x=1')).toBe(false);
+  });
+});

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -1,6 +1,43 @@
 // Audio and duration utilities
 import { getVideoDuration, isVideoUrl } from './videoUtils';
 
+const AUDIO_MIME_BY_EXTENSION: ReadonlyArray<readonly [string, string]> = [
+  ['.mp3', 'audio/mpeg'],
+  ['.m4a', 'audio/x-m4a'],
+  ['.m4b', 'audio/mp4'],
+  ['.aac', 'audio/aac'],
+  ['.flac', 'audio/flac'],
+  ['.wav', 'audio/wav'],
+  ['.opus', 'audio/opus'],
+  ['.oga', 'audio/ogg'],
+  ['.ogg', 'audio/ogg'],
+  ['.aiff', 'audio/aiff'],
+  ['.aif', 'audio/aiff'],
+  ['.wma', 'audio/x-ms-wma'],
+];
+
+function matchAudioExtension(url: string): string | null {
+  const lower = url.toLowerCase().split('?')[0].split('#')[0];
+  for (const [ext, mime] of AUDIO_MIME_BY_EXTENSION) {
+    if (lower.endsWith(ext)) return mime;
+  }
+  return null;
+}
+
+/**
+ * Detect audio MIME type from URL extension. Falls back to audio/mpeg.
+ */
+export function getAudioMimeType(url: string): string {
+  return matchAudioExtension(url) ?? 'audio/mpeg';
+}
+
+/**
+ * True when the URL ends with a recognized audio extension (mp3, flac, wav, m4a, aac, ogg, opus, aiff, wma).
+ */
+export function isKnownAudioFormat(url: string): boolean {
+  return matchAudioExtension(url) !== null;
+}
+
 /**
  * Get MP3 duration from URL using Audio API (works without CORS)
  */


### PR DESCRIPTION
Auto-detect enclosureType from the track URL's extension (mp3, flac,
wav, m4a, aac, ogg, opus, aiff, wma) instead of leaving audio tracks
pinned to audio/mpeg, and surface a warning below the field when the
URL doesn't end in a recognized audio extension so users catch typos
or wrong-file paste before publishing.