### PR TITLE
Suggest ID3v1 genres in keywords fields

### DIFF
--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -4,7 +4,7 @@ import { useNostr } from '../../store/nostrStore';
 import { LANGUAGES, PERSON_GROUPS, PERSON_ROLES, createEmptyPersonRole, createEmptyTrack, isVideoMedium, isCommunitySupport, createSupportRecipients, hasUserRecipients } from '../../types/feed';
 import type { PersonGroup } from '../../types/feed';
 import { FIELD_INFO } from '../../data/fieldInfo';
-import { ID3V1_GENRES } from '../../data/id3v1Genres';
+import { KeywordsField } from '../KeywordsField';
 import { detectAddressType } from '../../utils/addressUtils';
 import { getMediaDuration, secondsToHHMMSS, formatDuration, getAudioMimeType, isKnownAudioFormat } from '../../utils/audioUtils';
 import { getVideoMimeType } from '../../utils/videoUtils';
@@ -363,17 +363,11 @@ export function Editor() {
               </div>
               <div className="form-group">
                 <label className="form-label">Keywords<InfoIcon text={FIELD_INFO.keywords} /></label>
-                <input
-                  type="text"
-                  className="form-input"
-                  placeholder="rock, indie, guitar, electronic"
-                  list="id3v1-genres"
+                <KeywordsField
                   value={album.keywords || ''}
-                  onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { keywords: e.target.value } })}
+                  onChange={keywords => dispatch({ type: 'UPDATE_ALBUM', payload: { keywords } })}
+                  placeholder="rock, indie, guitar, electronic"
                 />
-                <datalist id="id3v1-genres">
-                  {ID3V1_GENRES.map(genre => <option key={genre} value={genre} />)}
-                </datalist>
               </div>
               <div className="form-group">
                 <label className="form-label">Owner Name<InfoIcon text={FIELD_INFO.ownerName} /></label>

--- a/src/components/Editor/Editor.tsx
+++ b/src/components/Editor/Editor.tsx
@@ -4,6 +4,7 @@ import { useNostr } from '../../store/nostrStore';
 import { LANGUAGES, PERSON_GROUPS, PERSON_ROLES, createEmptyPersonRole, createEmptyTrack, isVideoMedium, isCommunitySupport, createSupportRecipients, hasUserRecipients } from '../../types/feed';
 import type { PersonGroup } from '../../types/feed';
 import { FIELD_INFO } from '../../data/fieldInfo';
+import { ID3V1_GENRES } from '../../data/id3v1Genres';
 import { detectAddressType } from '../../utils/addressUtils';
 import { getMediaDuration, secondsToHHMMSS, formatDuration, getAudioMimeType, isKnownAudioFormat } from '../../utils/audioUtils';
 import { getVideoMimeType } from '../../utils/videoUtils';
@@ -366,9 +367,13 @@ export function Editor() {
                   type="text"
                   className="form-input"
                   placeholder="rock, indie, guitar, electronic"
+                  list="id3v1-genres"
                   value={album.keywords || ''}
                   onChange={e => dispatch({ type: 'UPDATE_ALBUM', payload: { keywords: e.target.value } })}
                 />
+                <datalist id="id3v1-genres">
+                  {ID3V1_GENRES.map(genre => <option key={genre} value={genre} />)}
+                </datalist>
               </div>
               <div className="form-group">
                 <label className="form-label">Owner Name<InfoIcon text={FIELD_INFO.ownerName} /></label>

--- a/src/components/Editor/PublisherEditor/PublisherInfoSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublisherInfoSection.tsx
@@ -2,7 +2,7 @@ import type { PublisherFeed } from '../../../types/feed';
 import { LANGUAGES } from '../../../types/feed';
 import type { FeedAction } from '../../../store/feedStore';
 import { FIELD_INFO } from '../../../data/fieldInfo';
-import { ID3V1_GENRES } from '../../../data/id3v1Genres';
+import { KeywordsField } from '../../KeywordsField';
 import { InfoIcon } from '../../InfoIcon';
 import { Section } from '../../Section';
 import { Toggle } from '../../Toggle';
@@ -102,17 +102,11 @@ export function PublisherInfoSection({ publisherFeed, dispatch }: PublisherInfoS
         </div>
         <div className="form-group">
           <label className="form-label">Keywords<InfoIcon text={FIELD_INFO.keywords} /></label>
-          <input
-            type="text"
-            className="form-input"
-            placeholder="label, publisher, music, indie"
-            list="id3v1-genres"
+          <KeywordsField
             value={publisherFeed.keywords || ''}
-            onChange={e => dispatch({ type: 'UPDATE_PUBLISHER_FEED', payload: { keywords: e.target.value } })}
+            onChange={keywords => dispatch({ type: 'UPDATE_PUBLISHER_FEED', payload: { keywords } })}
+            placeholder="label, publisher, music, indie"
           />
-          <datalist id="id3v1-genres">
-            {ID3V1_GENRES.map(genre => <option key={genre} value={genre} />)}
-          </datalist>
         </div>
         <div className="form-group">
           <label className="form-label">Owner Name<InfoIcon text={FIELD_INFO.ownerName} /></label>

--- a/src/components/Editor/PublisherEditor/PublisherInfoSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublisherInfoSection.tsx
@@ -2,6 +2,7 @@ import type { PublisherFeed } from '../../../types/feed';
 import { LANGUAGES } from '../../../types/feed';
 import type { FeedAction } from '../../../store/feedStore';
 import { FIELD_INFO } from '../../../data/fieldInfo';
+import { ID3V1_GENRES } from '../../../data/id3v1Genres';
 import { InfoIcon } from '../../InfoIcon';
 import { Section } from '../../Section';
 import { Toggle } from '../../Toggle';
@@ -105,9 +106,13 @@ export function PublisherInfoSection({ publisherFeed, dispatch }: PublisherInfoS
             type="text"
             className="form-input"
             placeholder="label, publisher, music, indie"
+            list="id3v1-genres"
             value={publisherFeed.keywords || ''}
             onChange={e => dispatch({ type: 'UPDATE_PUBLISHER_FEED', payload: { keywords: e.target.value } })}
           />
+          <datalist id="id3v1-genres">
+            {ID3V1_GENRES.map(genre => <option key={genre} value={genre} />)}
+          </datalist>
         </div>
         <div className="form-group">
           <label className="form-label">Owner Name<InfoIcon text={FIELD_INFO.ownerName} /></label>

--- a/src/components/KeywordsField.tsx
+++ b/src/components/KeywordsField.tsx
@@ -1,0 +1,96 @@
+import { ID3V1_GENRES } from '../data/id3v1Genres';
+
+interface KeywordsFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+function parseKeywords(value: string): string[] {
+  return value.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+function serializeKeywords(keywords: string[]): string {
+  return keywords.join(', ');
+}
+
+export function KeywordsField({ value, onChange, placeholder }: KeywordsFieldProps) {
+  const keywords = parseKeywords(value);
+
+  const removeKeyword = (index: number) => {
+    onChange(serializeKeywords(keywords.filter((_, i) => i !== index)));
+  };
+
+  const addKeyword = (keyword: string) => {
+    const trimmed = keyword.trim();
+    if (!trimmed) return;
+    if (keywords.some(k => k.toLowerCase() === trimmed.toLowerCase())) return;
+    onChange(serializeKeywords([...keywords, trimmed]));
+  };
+
+  return (
+    <>
+      {keywords.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginBottom: '8px' }}>
+          {keywords.map((kw, i) => (
+            <span
+              key={`${kw}-${i}`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '6px',
+                background: 'var(--bg-tertiary)',
+                padding: '4px 10px',
+                borderRadius: '12px',
+                fontSize: '13px',
+              }}
+            >
+              {kw}
+              <button
+                type="button"
+                onClick={() => removeKeyword(i)}
+                aria-label={`Remove ${kw}`}
+                title={`Remove ${kw}`}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: 'inherit',
+                  cursor: 'pointer',
+                  padding: 0,
+                  fontSize: '14px',
+                  lineHeight: 1,
+                }}
+              >
+                &#10005;
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <input
+          type="text"
+          className="form-input"
+          placeholder={placeholder}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          style={{ flex: 1, minWidth: 0 }}
+        />
+        <select
+          className="form-select"
+          value=""
+          onChange={e => {
+            if (e.target.value) addKeyword(e.target.value);
+          }}
+          style={{ minWidth: '150px' }}
+          aria-label="Add ID3v1 genre"
+        >
+          <option value="">+ Add genre</option>
+          {ID3V1_GENRES.map(g => (
+            <option key={g} value={g}>{g}</option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}

--- a/src/data/id3v1Genres.ts
+++ b/src/data/id3v1Genres.ts
@@ -1,0 +1,162 @@
+// MSP 2.0 - ID3v1 Genres
+// Canonical list of genres from the ID3v1 tag specification (0-79) plus the
+// Winamp extension (80-125) and Winamp 5.6+ extension (126-147).
+// Source: https://en.wikipedia.org/wiki/List_of_ID3v1_genres
+//
+// Surfaced as autocomplete suggestions on the comma-separated keywords input.
+// Kept in ID3v1 index order so the list is easy to diff against the spec.
+// Index 133 ("Negerpunk") is intentionally omitted — it is a racial slur, and
+// we do not need to preserve numeric index stability for a UI suggestion list.
+
+export const ID3V1_GENRES: readonly string[] = [
+  'Blues',                  // 0
+  'Classic Rock',           // 1
+  'Country',                // 2
+  'Dance',                  // 3
+  'Disco',                  // 4
+  'Funk',                   // 5
+  'Grunge',                 // 6
+  'Hip-Hop',                // 7
+  'Jazz',                   // 8
+  'Metal',                  // 9
+  'New Age',                // 10
+  'Oldies',                 // 11
+  'Other',                  // 12
+  'Pop',                    // 13
+  'Rhythm and Blues',       // 14
+  'Rap',                    // 15
+  'Reggae',                 // 16
+  'Rock',                   // 17
+  'Techno',                 // 18
+  'Industrial',             // 19
+  'Alternative',            // 20
+  'Ska',                    // 21
+  'Death Metal',            // 22
+  'Pranks',                 // 23
+  'Soundtrack',             // 24
+  'Euro-Techno',            // 25
+  'Ambient',                // 26
+  'Trip-Hop',               // 27
+  'Vocal',                  // 28
+  'Jazz & Funk',            // 29
+  'Fusion',                 // 30
+  'Trance',                 // 31
+  'Classical',              // 32
+  'Instrumental',           // 33
+  'Acid',                   // 34
+  'House',                  // 35
+  'Game',                   // 36
+  'Sound Clip',             // 37
+  'Gospel',                 // 38
+  'Noise',                  // 39
+  'Alternative Rock',       // 40
+  'Bass',                   // 41
+  'Soul',                   // 42
+  'Punk',                   // 43
+  'Space',                  // 44
+  'Meditative',             // 45
+  'Instrumental Pop',       // 46
+  'Instrumental Rock',      // 47
+  'Ethnic',                 // 48
+  'Gothic',                 // 49
+  'Darkwave',               // 50
+  'Techno-Industrial',      // 51
+  'Electronic',             // 52
+  'Pop-Folk',               // 53
+  'Eurodance',              // 54
+  'Dream',                  // 55
+  'Southern Rock',          // 56
+  'Comedy',                 // 57
+  'Cult',                   // 58
+  'Gangsta',                // 59
+  'Top 40',                 // 60
+  'Christian Rap',          // 61
+  'Pop/Funk',               // 62
+  'Jungle music',           // 63
+  'Native US',              // 64
+  'Cabaret',                // 65
+  'New Wave',               // 66
+  'Psychedelic',            // 67
+  'Rave',                   // 68
+  'Showtunes',              // 69
+  'Trailer',                // 70
+  'Lo-Fi',                  // 71
+  'Tribal',                 // 72
+  'Acid Punk',              // 73
+  'Acid Jazz',              // 74
+  'Polka',                  // 75
+  'Retro',                  // 76
+  'Musical',                // 77
+  "Rock 'n' Roll",          // 78
+  'Hard Rock',              // 79
+  // Winamp extension (80-125)
+  'Folk',                   // 80
+  'Folk-Rock',              // 81
+  'National Folk',          // 82
+  'Swing',                  // 83
+  'Fast Fusion',            // 84
+  'Bebop',                  // 85
+  'Latin',                  // 86
+  'Revival',                // 87
+  'Celtic',                 // 88
+  'Bluegrass',              // 89
+  'Avantgarde',             // 90
+  'Gothic Rock',            // 91
+  'Progressive Rock',       // 92
+  'Psychedelic Rock',       // 93
+  'Symphonic Rock',         // 94
+  'Slow Rock',              // 95
+  'Big Band',               // 96
+  'Chorus',                 // 97
+  'Easy Listening',         // 98
+  'Acoustic',               // 99
+  'Humour',                 // 100
+  'Speech',                 // 101
+  'Chanson',                // 102
+  'Opera',                  // 103
+  'Chamber Music',          // 104
+  'Sonata',                 // 105
+  'Symphony',               // 106
+  'Booty Bass',             // 107
+  'Primus',                 // 108
+  'Porn Groove',            // 109
+  'Satire',                 // 110
+  'Slow Jam',               // 111
+  'Club',                   // 112
+  'Tango',                  // 113
+  'Samba',                  // 114
+  'Folklore',               // 115
+  'Ballad',                 // 116
+  'Power Ballad',           // 117
+  'Rhythmic Soul',          // 118
+  'Freestyle',              // 119
+  'Duet',                   // 120
+  'Punk Rock',              // 121
+  'Drum Solo',              // 122
+  'A cappella',             // 123
+  'Euro-House',             // 124
+  'Dance Hall',             // 125
+  // Winamp 5.6+ extension (126-147)
+  'Goa music',              // 126
+  'Drum & Bass',            // 127
+  'Club-House',             // 128
+  'Hardcore Techno',        // 129
+  'Terror',                 // 130
+  'Indie',                  // 131
+  'BritPop',                // 132
+  // 133 intentionally omitted
+  'Polsk Punk',             // 134
+  'Beat',                   // 135
+  'Christian Gangsta Rap',  // 136
+  'Heavy Metal',            // 137
+  'Black Metal',            // 138
+  'Crossover',              // 139
+  'Contemporary Christian', // 140
+  'Christian Rock',         // 141
+  'Merengue',               // 142
+  'Salsa',                  // 143
+  'Thrash Metal',           // 144
+  'Anime',                  // 145
+  'Jpop',                   // 146
+  'Synthpop',               // 147
+];


### PR DESCRIPTION
## Summary
- Adds `src/data/id3v1Genres.ts` — the canonical [ID3v1 genre list](https://en.wikipedia.org/wiki/List_of_ID3v1_genres) (indexes 0–147, kept in spec order for easy diffing against the reference).
- Wires a `<datalist>` of those genres onto the **Album / Video** keywords input (`Editor.tsx`) and the **Publisher** keywords input (`PublisherInfoSection.tsx`), so users get familiar genre names as native browser autocomplete suggestions.
- The keywords field stays free-form text — nothing about the data model, XML output, or existing feeds changes. This is purely a UX hint.

## Notes
- Index 133 from the Wikipedia list is intentionally omitted (it's a racial slur). Numeric index stability doesn't matter here since we only use the strings as autocomplete options, not as numeric IDs.
- No new type, store, or XML-layer changes, so imported feeds keep whatever keyword strings they already have.

## Test plan
- [ ] `npm run build` succeeds (verified locally)
- [ ] Open the Album editor → focus the Keywords input → confirm the native datalist dropdown shows ID3v1 genres and narrows as you type (e.g., "jaz" → Jazz, Jazz & Funk, Acid Jazz)
- [ ] Same check on the Video editor (shares the Album editor form)
- [ ] Same check on the Publisher editor's Keywords input
- [ ] Typing a non-listed keyword still works and saves normally
- [ ] Typing a comma to add a second keyword continues to work (datalist does not block free text)

https://claude.ai/code/session_01HNr5sU2RkNHzmrw44zd8JY

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNr5sU2RkNHzmrw44zd8JY)_