### PR TITLE
Validate RSS feed URLs for characters that cause Podcast Index duplicates

### DIFF
--- a/api/pubnotify.ts
+++ b/api/pubnotify.ts
@@ -25,6 +25,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid URL format' });
   }
 
+  // Reject URLs with characters that cause Podcast Index indexing issues or duplicates
+  if (/ /.test(url)) {
+    return res.status(400).json({ error: 'URL contains spaces. Please percent-encode spaces as %20 before submitting.' });
+  }
+  if (/'/.test(url)) {
+    return res.status(400).json({ error: "URL contains apostrophes ('). Podcast Index may encode them as %27 and create a duplicate entry. Rename the file to remove apostrophes before submitting." });
+  }
+  if (/[<>"{}|\\^`]/.test(url)) {
+    return res.status(400).json({ error: 'URL contains special characters (<, >, ", {, }, |, \\, ^, `) that require percent-encoding. Please fix the URL before submitting.' });
+  }
+  if (Array.from(url).some(c => c.charCodeAt(0) > 127)) {
+    return res.status(400).json({ error: 'URL contains non-ASCII characters that require percent-encoding. Please fix the URL before submitting.' });
+  }
+
   try {
     // First, notify Podcast Index about the feed (no auth required)
     const pubnotifyUrl = `https://api.podcastindex.org/api/1.0/hub/pubnotify?url=${encodeURIComponent(url)}`;

--- a/src/components/Editor/PublisherEditor/PublisherFeedReminderSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublisherFeedReminderSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { PublisherFeed } from '../../../types/feed';
+import { getFeedUrlError } from '../../../utils/urlValidation';
 import { Section } from '../../Section';
 import { generatePublisherRssFeed, downloadXml } from '../../../utils/xmlGenerator';
 import {
@@ -28,6 +29,7 @@ export function PublisherFeedReminderSection({ publisherFeed }: PublisherFeedRem
   const podcastGuid = publisherFeed.podcastGuid;
   const existingInfo = podcastGuid ? getHostedFeedInfo(podcastGuid) : null;
   const isAlreadyHosted = !!existingInfo;
+  const selfHostedUrlError = getFeedUrlError(selfHostedUrl.trim());
 
   const handleHostOnMSP = async () => {
     if (!podcastGuid) {
@@ -189,7 +191,7 @@ export function PublisherFeedReminderSection({ publisherFeed }: PublisherFeedRem
                 flex: 1,
                 padding: '8px 12px',
                 borderRadius: '4px',
-                border: '1px solid var(--border-color)',
+                border: `1px solid ${selfHostedUrlError ? 'var(--error, #ef4444)' : 'var(--border-color)'}`,
                 backgroundColor: 'var(--bg-secondary)',
                 color: 'var(--text-primary)',
                 fontSize: '13px',
@@ -199,11 +201,16 @@ export function PublisherFeedReminderSection({ publisherFeed }: PublisherFeedRem
             <button
               className="btn btn-secondary"
               onClick={handleSubmitToPodcastIndex}
-              disabled={isSubmitting || !selfHostedUrl.trim()}
+              disabled={isSubmitting || !selfHostedUrl.trim() || !!selfHostedUrlError}
             >
               {isSubmitting ? 'Submitting...' : 'Submit to PI'}
             </button>
           </div>
+          {selfHostedUrlError && (
+            <p style={{ color: 'var(--error, #ef4444)', fontSize: '13px', marginTop: '6px', marginBottom: 0 }}>
+              {selfHostedUrlError}
+            </p>
+          )}
           {piResult && (
             <p style={{
               color: piResult.success ? 'var(--success-color, #22c55e)' : 'var(--danger-color, #ef4444)',

--- a/src/components/modals/PodcastIndexModal.tsx
+++ b/src/components/modals/PodcastIndexModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { ModalWrapper } from './ModalWrapper';
 import { getHostedFeedInfo, buildHostedUrl } from '../../utils/hostedFeed';
+import { getFeedUrlError } from '../../utils/urlValidation';
 
 interface PodcastIndexModalProps {
   onClose: () => void;
@@ -58,6 +59,8 @@ export function PodcastIndexModal({ onClose, feedGuid, medium }: PodcastIndexMod
     }
   };
 
+  const urlError = getFeedUrlError(podcastIndexUrl.trim());
+
   return (
     <ModalWrapper
       isOpen={true}
@@ -68,7 +71,7 @@ export function PodcastIndexModal({ onClose, feedGuid, medium }: PodcastIndexMod
           <button
             className="btn btn-primary"
             onClick={handleSubmit}
-            disabled={submitting || !podcastIndexUrl.trim()}
+            disabled={submitting || !podcastIndexUrl.trim() || !!urlError}
           >
             {submitting ? 'Submitting...' : 'Submit'}
           </button>
@@ -94,13 +97,18 @@ export function PodcastIndexModal({ onClose, feedGuid, medium }: PodcastIndexMod
             width: '100%',
             padding: '8px 12px',
             borderRadius: '4px',
-            border: '1px solid var(--border-color)',
+            border: `1px solid ${urlError ? 'var(--error, #ef4444)' : 'var(--border-color)'}`,
             backgroundColor: 'var(--bg-secondary)',
             color: 'var(--text-primary)',
             fontSize: '0.875rem',
             fontFamily: 'monospace'
           }}
         />
+        {urlError && (
+          <div style={{ marginTop: '6px', fontSize: '0.8rem', color: 'var(--error, #ef4444)' }}>
+            {urlError}
+          </div>
+        )}
       </div>
       {podcastIndexPageUrl && (
         <div style={{

--- a/src/utils/urlValidation.ts
+++ b/src/utils/urlValidation.ts
@@ -1,0 +1,48 @@
+function hasNonAscii(url: string): boolean {
+  for (let i = 0; i < url.length; i++) {
+    if (url.charCodeAt(i) > 127) return true;
+  }
+  return false;
+}
+
+const CHECKS: Array<{ test: (url: string) => boolean; label: string; detail: string }> = [
+  {
+    test: (url) => url.includes(' '),
+    label: 'spaces',
+    detail: 'Spaces are not valid in URLs and will cause submission errors.',
+  },
+  {
+    test: (url) => url.includes("'"),
+    label: "apostrophes (')",
+    detail:
+      "Podcast Index may encode apostrophes as %27, creating a duplicate feed entry. Rename the file to remove them.",
+  },
+  {
+    test: (url) => /[<>"{}|\\^`]/.test(url),
+    label: 'special characters (<, >, ", {, }, |, \\, ^, `)',
+    detail: 'These characters require percent-encoding and may cause indexing issues.',
+  },
+  {
+    test: hasNonAscii,
+    label: 'non-ASCII characters',
+    detail: 'Non-ASCII characters require percent-encoding and may cause indexing issues.',
+  },
+];
+
+export function getFeedUrlError(url: string): string | null {
+  if (!url) return null;
+
+  const found: string[] = [];
+  let detail = '';
+
+  for (const { test, label, detail: d } of CHECKS) {
+    if (test(url)) {
+      found.push(label);
+      if (!detail) detail = d;
+    }
+  }
+
+  if (found.length === 0) return null;
+
+  return `URL contains ${found.join(', ')}. ${detail} Please fix the URL before submitting to Podcast Index.`;
+}


### PR DESCRIPTION
Adds getFeedUrlError() utility that flags spaces, apostrophes ('), and
other special characters which some systems percent-encode inconsistently,
causing Podcast Index to create duplicate feed entries (e.g. ' → %27).

Both manual URL entry points (PodcastIndexModal and
PublisherFeedReminderSection) now show an inline error and disable
submission until the URL is clean. The /api/pubnotify backend mirrors
the same checks as a belt-and-suspenders guard.

https://claude.ai/code/session_01QMAzuoLi5bZursyK7dHY1j