### PR TITLE
Add Nostr signer timeout and pre-flight connection check

### DIFF
--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../utils/hostedFeed';
 import { albumStorage, videoStorage, publisherStorage, pendingHostedStorage } from '../../utils/storage';
 import { useNostr } from '../../store/nostrStore';
+import { checkSignerConnection } from '../../utils/nostrSigner';
 import { ModalWrapper } from './ModalWrapper';
 
 const DEFAULT_BLOSSOM_SERVER = 'https://blossom.primal.net/';
@@ -296,6 +297,17 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
 
       if (errors.length > 0) {
         setMessage({ type: 'error', text: `Missing required fields: ${errors.join(', ')}` });
+        setLoading(false);
+        return;
+      }
+    }
+
+    // Pre-flight: verify signer is reachable before any Nostr operation
+    const nostrSignModes = ['nostr', 'nostrMusic', 'blossom', 'nsite'] as const;
+    if ((nostrSignModes as readonly string[]).includes(mode)) {
+      const health = await checkSignerConnection();
+      if (!health.connected) {
+        setMessage({ type: 'error', text: health.error ?? 'Nostr signer is not connected.' });
         setLoading(false);
         return;
       }

--- a/src/utils/adminAuth.ts
+++ b/src/utils/adminAuth.ts
@@ -1,5 +1,5 @@
 // Admin authentication utilities for frontend
-import { getSigner, hasSigner } from './nostrSigner';
+import { hasSigner, signEventWithTimeout } from './nostrSigner';
 
 interface NostrEvent {
   id?: string;
@@ -29,7 +29,6 @@ async function signAuthEvent(url: string, method: string): Promise<NostrEvent> {
     throw new Error('Not logged in');
   }
 
-  const signer = getSigner();
   const event = {
     kind: 27235,
     created_at: Math.floor(Date.now() / 1000),
@@ -40,7 +39,7 @@ async function signAuthEvent(url: string, method: string): Promise<NostrEvent> {
     content: ''
   };
 
-  return await signer.signEvent(event) as NostrEvent;
+  return await signEventWithTimeout(event) as NostrEvent;
 }
 
 // Full authentication flow
@@ -74,7 +73,6 @@ export async function createAdminAuthHeader(url: string, method: string): Promis
     throw new Error('Not logged in');
   }
 
-  const signer = getSigner();
   const event = {
     kind: 27235,
     created_at: Math.floor(Date.now() / 1000),
@@ -85,7 +83,7 @@ export async function createAdminAuthHeader(url: string, method: string): Promis
     content: ''
   };
 
-  const signedEvent = await signer.signEvent(event);
+  const signedEvent = await signEventWithTimeout(event);
   const eventJson = JSON.stringify(signedEvent);
   const base64Event = btoa(eventJson);
 

--- a/src/utils/blossom.ts
+++ b/src/utils/blossom.ts
@@ -4,7 +4,7 @@ import type { NostrEvent } from '../types/nostr';
 import { generateRssFeed, generatePublisherRssFeed } from './xmlGenerator';
 import { hexToNpub } from './nostr';
 import { DEFAULT_RELAYS, publishEventToRelays } from './nostrRelay';
-import { getSigner, hasSigner } from './nostrSigner';
+import { getSigner, hasSigner, signEventWithTimeout } from './nostrSigner';
 
 // Blossom auth event kind
 const BLOSSOM_AUTH_KIND = 24242;
@@ -94,7 +94,7 @@ async function publishFileMetadata(
     const signer = getSigner();
     const pubkey = await signer.getPublicKey();
     const unsignedEvent = createFileMetadataEvent(blossomUrl, hash, fileSize, album, pubkey);
-    const signedEvent = await signer.signEvent(unsignedEvent);
+    const signedEvent = await signEventWithTimeout(unsignedEvent);
 
     const { successCount } = await publishEventToRelays(signedEvent as NostrEvent, relays);
 
@@ -130,7 +130,7 @@ export async function uploadToBlossom(
 
     // Create and sign auth event
     const authEvent = await createBlossomAuthEvent(hash, pubkey, 'upload');
-    const signedAuthEvent = await signer.signEvent(authEvent);
+    const signedAuthEvent = await signEventWithTimeout(authEvent);
 
     // Base64 encode the signed event for Authorization header
     const authHeader = 'Nostr ' + btoa(JSON.stringify(signedAuthEvent));
@@ -226,7 +226,7 @@ export async function uploadFeedToBlossom(
 
     // Create and sign auth event
     const authEvent = await createBlossomAuthEvent(hash, pubkey, 'upload');
-    const signedAuthEvent = await signer.signEvent(authEvent);
+    const signedAuthEvent = await signEventWithTimeout(authEvent);
 
     // Base64 encode the signed event for Authorization header
     const authHeader = 'Nostr ' + btoa(JSON.stringify(signedAuthEvent));

--- a/src/utils/nostrSigner.ts
+++ b/src/utils/nostrSigner.ts
@@ -217,7 +217,7 @@ export async function waitForNip46Connection(
     storeConnectionMethod('nip46');
 
     return userPubkey;
-  } catch (e) {
+  } catch {
     pool.close(NIP46_RELAYS);
     throw new Error('Connection timeout - no response from signer');
   }
@@ -274,6 +274,69 @@ export function getSigner(): NostrSigner {
     throw new Error('No signer initialized. Please log in first.');
   }
   return currentSigner;
+}
+
+// Sign an event with a timeout so a non-responsive remote signer doesn't hang the UI indefinitely.
+// Default: 60 s for NIP-46 (user may need to unlock phone + tap), 30 s for NIP-07 (local extension popup).
+export async function signEventWithTimeout(
+  event: EventTemplate,
+  timeoutMs?: number
+): Promise<VerifiedEvent> {
+  const method = currentMethod;
+  const effectiveTimeout = timeoutMs ?? (method === 'nip46' ? 60_000 : 30_000);
+
+  return Promise.race([
+    getSigner().signEvent(event),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(
+          'Signer request timed out. If you use a remote signer app (like Amber or nsecBunker), please open it and approve the pending request, then try again.'
+        )),
+        effectiveTimeout
+      )
+    ),
+  ]);
+}
+
+// Check whether the signer is reachable before starting a Nostr operation.
+// Returns { connected: true } quickly or { connected: false, error } without throwing.
+export async function checkSignerConnection(timeoutMs?: number): Promise<{ connected: boolean; error?: string }> {
+  if (!hasSigner()) {
+    return { connected: false, error: 'Not logged in to Nostr. Please log in and try again.' };
+  }
+
+  const method = currentMethod;
+
+  try {
+    if (method === 'nip46') {
+      const pubkey = await reconnectNip46(timeoutMs ?? 5_000);
+      if (!pubkey) {
+        return {
+          connected: false,
+          error: 'Could not reach your remote signer. Make sure the signer app is open and connected, then try again.'
+        };
+      }
+      return { connected: true };
+    } else {
+      // NIP-07: race getPublicKey against a short timeout
+      await Promise.race([
+        getSigner().getPublicKey(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), timeoutMs ?? 3_000)
+        ),
+      ]);
+      return { connected: true };
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    if (msg === 'timeout') {
+      return {
+        connected: false,
+        error: 'Could not reach your browser extension. Make sure it is unlocked and try again.'
+      };
+    }
+    return { connected: false, error: msg };
+  }
 }
 
 // Check if a signer is active

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -10,7 +10,7 @@ import {
   collectEvents,
   publishEventToRelays
 } from './nostrRelay';
-import { getSigner, hasSigner } from './nostrSigner';
+import { getSigner, hasSigner, signEventWithTimeout } from './nostrSigner';
 import { parseNostrMusicEvent } from './nostrMusicConverter';
 
 // Re-export for backward compatibility
@@ -130,7 +130,7 @@ export async function saveAlbumToNostr(
 
     // Create and sign the event
     const unsignedEvent = createFeedEvent(rssXml, album.podcastGuid, album.title, pubkey);
-    const signedEvent = await signer.signEvent(unsignedEvent);
+    const signedEvent = await signEventWithTimeout(unsignedEvent);
 
     // Publish to relays
     const { successCount } = await publishEventToRelays(signedEvent as NostrEvent, relays);
@@ -189,7 +189,7 @@ export async function saveFeedToNostr(
 
     // Create and sign the event
     const unsignedEvent = createFeedEvent(rssXml, feedGuid, feedTitle, pubkey);
-    const signedEvent = await signer.signEvent(unsignedEvent);
+    const signedEvent = await signEventWithTimeout(unsignedEvent);
 
     // Publish to relays
     const { successCount } = await publishEventToRelays(signedEvent as NostrEvent, relays);
@@ -681,7 +681,7 @@ export async function publishNostrMusicTracks(
 
       // Create and sign the event
       const unsignedEvent = createMusicTrackEvent(track, album, pubkey);
-      const signedEvent = await signer.signEvent(unsignedEvent);
+      const signedEvent = await signEventWithTimeout(unsignedEvent);
 
       // Publish to all relays
       const { successCount } = await publishEventToRelays(signedEvent as NostrEvent, relays);
@@ -707,7 +707,7 @@ export async function publishNostrMusicTracks(
       }
 
       const playlistEvent = createMusicPlaylistEvent(album, publishedTracks, pubkey);
-      const signedPlaylist = await signer.signEvent(playlistEvent);
+      const signedPlaylist = await signEventWithTimeout(playlistEvent);
       const { successCount: playlistSuccessCount } = await publishEventToRelays(signedPlaylist as NostrEvent, relays);
 
       if (playlistSuccessCount > 0) {
@@ -780,7 +780,7 @@ export async function deleteNostrMusicTracks(
       content: 'Unpublished from MSP 2.0'
     };
 
-    const signedEvent = await signer.signEvent(deletionEvent);
+    const signedEvent = await signEventWithTimeout(deletionEvent);
     const { successCount } = await publishEventToRelays(signedEvent as NostrEvent, relays);
 
     if (successCount === 0) {

--- a/src/utils/nsite.ts
+++ b/src/utils/nsite.ts
@@ -6,7 +6,7 @@ import type { Album, PublisherFeed } from '../types/feed';
 import type { NostrEvent } from '../types/nostr';
 import { generateRssFeed, generatePublisherRssFeed } from './xmlGenerator';
 import { DEFAULT_RELAYS, publishEventToRelays } from './nostrRelay';
-import { getSigner, hasSigner } from './nostrSigner';
+import { getSigner, hasSigner, signEventWithTimeout } from './nostrSigner';
 
 // NIP-5A event kinds
 const NSITE_NAMED_KIND = 35128;
@@ -183,7 +183,7 @@ export async function publishToNsite(
     const hash = await sha256Hash(rssXml);
 
     const authEvent = await createBlossomAuthEvent(hash, pubkey);
-    const signedAuth = await signer.signEvent(authEvent);
+    const signedAuth = await signEventWithTimeout(authEvent);
     const authHeader = 'Nostr ' + btoa(JSON.stringify(signedAuth));
 
     const serverUrl = blossomServer.replace(/\/$/, '');
@@ -215,7 +215,7 @@ export async function publishToNsite(
       NSITE_RELAYS
     );
 
-    const signedManifest = await signer.signEvent(manifest);
+    const signedManifest = await signEventWithTimeout(manifest);
     const { successCount } = await publishEventToRelays(signedManifest as NostrEvent, NSITE_RELAYS);
 
     if (successCount === 0) {


### PR DESCRIPTION
All signer.signEvent() calls are now wrapped with signEventWithTimeout()
(60 s for NIP-46, 30 s for NIP-07) so a non-responsive remote signer
app no longer hangs the UI indefinitely. A checkSignerConnection()
pre-flight is run in SaveModal before any Nostr operation, surfacing
a clear error immediately if the signer is unreachable.

Affected files: nostrSigner.ts (new helpers), adminAuth.ts, blossom.ts,
nsite.ts, nostrSync.ts (12 signEvent call sites replaced), SaveModal.tsx
(pre-flight check added).

Co-Authored-By: Claude <noreply@anthropic.com>
https://claude.ai/code/session_01CQFFzGm1c4pKa2zUUkvfDo