### PR TITLE
Fix publisher feed Podcast Index submission

### DIFF
--- a/src/components/Editor/PublisherEditor/PublishSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublishSection.tsx
@@ -232,13 +232,18 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
           <span style={{ flex: 1, fontWeight: 500 }}>Notify Podcast Index</span>
           <span style={{
             fontSize: '13px',
-            color: stepStates.notifying === 'complete' ? 'var(--success-color)' :
-              stepStates.notifying === 'error' ? 'var(--danger-color)' :
-                'var(--text-secondary)'
+            color: stepStates.notifying === 'complete'
+              ? (publishResult?.piStatus === 'failed' ? 'var(--danger-color)' : 'var(--success-color)')
+              : stepStates.notifying === 'error' ? 'var(--danger-color)'
+              : 'var(--text-secondary)'
           }}>
             {stepStates.notifying === 'pending' ? 'Not started' :
               stepStates.notifying === 'in-progress' ? 'Notifying...' :
-              stepStates.notifying === 'complete' ? (publishResult?.piStatus === 'indexed' ? 'Indexed' : 'Notified') : 'Failed'}
+              stepStates.notifying === 'complete'
+                ? (publishResult?.piStatus === 'indexed' ? 'Indexed'
+                   : publishResult?.piStatus === 'failed' ? 'Failed'
+                   : 'Notified')
+                : 'Failed'}
           </span>
         </div>
 
@@ -496,7 +501,7 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
           </div>
 
           {/* Podcast Index Link */}
-          {(publishResult?.piPageUrl || publishResult?.piStatus === 'pending') && (
+          {(publishResult?.piPageUrl || publishResult?.piStatus === 'pending' || publishResult?.piStatus === 'failed') && (
             <div style={{ paddingTop: '12px', borderTop: '1px solid var(--border-color)' }}>
               <label style={{
                 display: 'block',
@@ -515,6 +520,10 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
                 >
                   {publishResult.piPageUrl}
                 </a>
+              ) : publishResult.piStatus === 'failed' ? (
+                <p style={{ fontSize: '13px', color: 'var(--danger-color)', margin: 0 }}>
+                  Failed to notify Podcast Index. Feed was hosted successfully — you can retry via Save → Submit to PodcastIndex.
+                </p>
               ) : (
                 <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: 0 }}>
                   Feed submitted to Podcast Index. It may take a few minutes to appear.

--- a/src/components/Editor/PublisherEditor/PublisherFeedReminderSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublisherFeedReminderSection.tsx
@@ -80,11 +80,10 @@ export function PublisherFeedReminderSection({ publisherFeed }: PublisherFeedRem
 
       // Auto-submit to Podcast Index
       try {
-        await fetch('/api/pisubmit', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ url: feedUrl })
-        });
+        const piParams = new URLSearchParams({ url: feedUrl });
+        if (publisherFeed.medium) piParams.set('medium', publisherFeed.medium);
+        if (publisherFeed.podcastGuid) piParams.set('guid', publisherFeed.podcastGuid);
+        await fetch(`/api/pubnotify?${piParams}`);
       } catch {
         // Silent fail for PI submission - feed is still hosted
       }

--- a/src/utils/publisherPublish.ts
+++ b/src/utils/publisherPublish.ts
@@ -89,13 +89,16 @@ const isCorsOrNetworkError = (errMsg: string): boolean => {
 
 // Notify Podcast Index about a feed update. Medium is forwarded to podping so indexers and
 // the MSP consumer can classify the feed correctly (pp_music_update vs pp_podcast_update).
+// guid enables the faster GUID-based lookup on the PI side, returning the PI page URL immediately.
 async function notifyPodcastIndex(
   feedUrl: string,
-  medium?: string
+  medium?: string,
+  guid?: string
 ): Promise<{ status: 'indexed' | 'pending' | 'failed'; pageUrl?: string }> {
   try {
     const params = new URLSearchParams({ url: feedUrl });
     if (medium) params.set('medium', medium);
+    if (guid) params.set('guid', guid);
     const res = await fetch(`/api/pubnotify?${params}`);
     const data = await res.json();
     if (data.success) {
@@ -565,7 +568,7 @@ export async function publishPublisherFeed(
 
   // Step 3: Notify Podcast Index
   onProgress({ step: 'notifying', message: 'Notifying Podcast Index...' });
-  const piResult = await notifyPodcastIndex(feedUrl, updatedPublisherFeed.medium);
+  const piResult = await notifyPodcastIndex(feedUrl, updatedPublisherFeed.medium, updatedPublisherFeed.podcastGuid);
 
   // Step 4: Update catalog feeds with publisher reference (if requested)
   let catalogUpdateResults: FeedUpdateResult[] | undefined;


### PR DESCRIPTION
Three bugs prevented publisher feeds from correctly submitting to Podcast
Index and reporting results in the UI:

1. publisherPublish.ts: notifyPodcastIndex never passed podcastGuid to
   /api/pubnotify. Without it, PI could only do a URL-based lookup, which
   returns nothing for freshly created feeds — resulting in 'pending'
   forever instead of 'indexed' with a PI page link. Now passes guid so the
   faster GUID-based lookup runs immediately after publish.

2. PublishSection.tsx: piStatus 'failed' was rendered identically to
   'pending' (both showed "Notified" in neutral colour, PI result block
   hidden on failure). Now shows "Failed" in danger colour and a visible
   error message with retry instructions.

3. PublisherFeedReminderSection.tsx: handleHostOnMSP called /api/pisubmit
   (POST, add/byfeedurl only) instead of /api/pubnotify (GET, full
   pubnotify + podping + lookup flow). Replaced with /api/pubnotify passing
   url, medium, and guid.

Co-Authored-By: claude <noreply@anthropic.com>

https://claude.ai/code/session_01HMrJTuT51v5ooAkayJ3CQG