### PR TITLE
Add dead-simple new artist onboarding wizard

### DIFF
--- a/api/hosted/[feedId].ts
+++ b/api/hosted/[feedId].ts
@@ -4,19 +4,18 @@ import { parseAuthHeader, parseFeedAuthHeader } from '../_utils/adminAuth.js';
 import {
   notifyPodcastIndex,
   getBaseUrl,
-  hashToken,
   isValidFeedId
 } from '../_utils/feedUtils.js';
 import { extractPodcastMedium } from '../_utils/xmlUtils.js';
 
 // Metadata stored in separate .meta.json blob
 interface FeedMetadata {
-  editTokenHash: string;
+  editTokenHash?: string;  // Legacy — no longer generated for new feeds
   createdAt: string;
   lastUpdated?: string;
   title?: string;
-  ownerPubkey?: string;  // Nostr pubkey (hex) - if linked
-  linkedAt?: string;     // When Nostr was linked
+  ownerPubkey?: string;
+  linkedAt?: string;
   podcastIndexId?: number;
 }
 
@@ -65,8 +64,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
     res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Edit-Token, Authorization, X-Admin-Key');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Admin-Key');
     return res.status(204).end();
   }
 
@@ -201,60 +200,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(404).json({ error: 'Feed not found' });
         }
 
-        // Get metadata from .meta.json
+        // Get metadata
         const metadata = await getMetadata(feedId as string);
+        const ownerPubkey = metadata?.ownerPubkey;
+        const createdAt = metadata?.createdAt ?? Date.now().toString();
+        const existingTitle = metadata?.title;
+        const existingPodcastIndexId = metadata?.podcastIndexId;
 
-        // Auto-repair: if metadata is missing, require token to create it
-        let storedHash: string;
-        let createdAt: string;
-        let existingTitle: string | undefined;
-        let ownerPubkey: string | undefined;
-        let linkedAt: string | undefined;
-        let existingPodcastIndexId: number | undefined;
-
-        const editToken = req.headers['x-edit-token'];
-        const authHeader = req.headers['authorization'] as string | undefined;
-
-        if (!metadata) {
-          // Legacy feed without metadata - require token to migrate
-          if (!editToken || typeof editToken !== 'string') {
-            return res.status(401).json({ error: 'Missing edit token' });
+        // Validate auth: Nostr owner or admin
+        if (!isAdmin) {
+          if (!ownerPubkey) {
+            // Feed has no Nostr owner — admin-only management
+            return res.status(403).json({ error: 'This feed has no Nostr owner. Contact an admin to update it.' });
           }
-          storedHash = hashToken(editToken);
-          createdAt = Date.now().toString();
-          existingTitle = undefined;
-          ownerPubkey = undefined;
-          linkedAt = undefined;
-          existingPodcastIndexId = undefined;
-        } else {
-          storedHash = metadata.editTokenHash;
-          createdAt = metadata.createdAt;
-          existingTitle = metadata.title;
-          ownerPubkey = metadata.ownerPubkey;
-          linkedAt = metadata.linkedAt;
-          existingPodcastIndexId = metadata.podcastIndexId;
-
-          // Validate auth: accept either token or Nostr (if linked)
-          let isAuthorized = false;
-
-          // Try token auth first
-          if (editToken && typeof editToken === 'string') {
-            const providedHash = hashToken(editToken);
-            if (storedHash === providedHash) {
-              isAuthorized = true;
-            }
-          }
-
-          // Try Nostr auth if token didn't work and feed has owner
-          if (!isAuthorized && ownerPubkey && authHeader?.startsWith('Nostr ')) {
-            const nostrAuth = await parseFeedAuthHeader(authHeader);
-            if (nostrAuth.valid && nostrAuth.pubkey === ownerPubkey) {
-              isAuthorized = true;
-            }
-          }
-
-          if (!isAuthorized) {
-            return res.status(403).json({ error: 'Invalid credentials' });
+          const putAuth = req.headers['authorization'] as string | undefined;
+          const nostrPutAuth = await parseFeedAuthHeader(putAuth);
+          if (!nostrPutAuth.valid || nostrPutAuth.pubkey !== ownerPubkey) {
+            return res.status(403).json({ error: 'Nostr authentication required — sign in with the key that created this feed' });
           }
         }
 
@@ -298,12 +260,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const podcastIndexId = newPodcastIndexId || existingPodcastIndexId;
 
         await put(metaPath, JSON.stringify({
-          editTokenHash: storedHash,
           createdAt,
           lastUpdated: Date.now().toString(),
           title: (typeof title === 'string' ? title : existingTitle || 'Untitled Feed').slice(0, 200),
           ownerPubkey,
-          linkedAt,
+          linkedAt: metadata?.linkedAt,
           podcastIndexId
         }), {
           access: 'public',
@@ -314,77 +275,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return res.status(200).json({ success: true, podcastIndexId });
       }
 
-      case 'PATCH': {
-        // Link Nostr identity to existing feed
-        // Requires BOTH token (proves ownership) AND Nostr auth (identity to link)
-        const editToken = req.headers['x-edit-token'];
-        const authHeader = req.headers['authorization'] as string | undefined;
-
-        if (!editToken || typeof editToken !== 'string') {
-          return res.status(401).json({ error: 'Edit token required to link Nostr identity' });
-        }
-
-        const metadata = await getMetadata(feedId as string);
-        if (!metadata) {
-          return res.status(404).json({ error: 'Feed not found' });
-        }
-
-        // Validate token
-        const providedHash = hashToken(editToken);
-        if (metadata.editTokenHash !== providedHash) {
-          return res.status(403).json({ error: 'Invalid edit token' });
-        }
-
-        // Parse and validate Nostr auth
-        const nostrAuth = await parseFeedAuthHeader(authHeader);
-        if (!nostrAuth.valid || !nostrAuth.pubkey) {
-          return res.status(400).json({ error: nostrAuth.error || 'Invalid Nostr authentication' });
-        }
-
-        // Update metadata with new owner
-        const metaPath = `feeds/${feedId}.meta.json`;
-        const { blobs: metaBlobs } = await list({ prefix: metaPath });
-        const existingMeta = metaBlobs.find(b => b.pathname === metaPath);
-        if (existingMeta) {
-          await del(existingMeta.url);
-        }
-
-        await put(metaPath, JSON.stringify({
-          ...metadata,
-          ownerPubkey: nostrAuth.pubkey,
-          linkedAt: Date.now().toString()
-        }), {
-          access: 'public',
-          contentType: 'application/json',
-          addRandomSuffix: false
-        });
-
-        return res.status(200).json({
-          success: true,
-          message: 'Nostr identity linked successfully',
-          pubkey: nostrAuth.pubkey
-        });
-      }
-
       case 'DELETE': {
-        // Admin can delete without edit token
+        // Validate Nostr auth for non-admin
         if (!isAdmin) {
-          // Validate edit token for non-admin
-          const editToken = req.headers['x-edit-token'];
-          if (!editToken || typeof editToken !== 'string') {
-            return res.status(401).json({ error: 'Missing edit token' });
-          }
-
-          // Get metadata from .meta.json
           const metadata = await getMetadata(feedId as string);
-          const providedHash = hashToken(editToken);
-
-          // For legacy feeds without metadata, allow deletion with any token
-          // (can't verify, but feed is unusable anyway)
-          if (metadata) {
-            if (metadata.editTokenHash !== providedHash) {
-              return res.status(403).json({ error: 'Invalid edit token' });
-            }
+          const ownerPubkey = metadata?.ownerPubkey;
+          if (!ownerPubkey) {
+            return res.status(403).json({ error: 'This feed has no Nostr owner. Contact an admin to delete it.' });
+          }
+          const delAuth = req.headers['authorization'] as string | undefined;
+          const nostrDelAuth = await parseFeedAuthHeader(delAuth);
+          if (!nostrDelAuth.valid || nostrDelAuth.pubkey !== ownerPubkey) {
+            return res.status(403).json({ error: 'Nostr authentication required — sign in with the key that created this feed' });
           }
         }
 

--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -1,20 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { put, list } from '@vercel/blob';
-import { randomBytes } from 'crypto';
 import { parseAuthHeader, parseFeedAuthHeader } from '../_utils/adminAuth.js';
 import {
   notifyPodcastIndex,
   lookupPodcastIndexId,
   getBaseUrl,
-  hashToken,
   isValidFeedId
 } from '../_utils/feedUtils.js';
 import { extractPodcastMedium } from '../_utils/xmlUtils.js';
-
-// Generate a secure edit token
-function generateEditToken(): string {
-  return randomBytes(32).toString('base64url');
-}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // GET - List feeds (admin sees all, regular users see their own)
@@ -109,7 +102,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const { xml, title, podcastGuid, editToken: clientToken } = req.body;
+    const { xml, title, podcastGuid } = req.body;
 
     // Validate input
     if (!xml || typeof xml !== 'string') {
@@ -135,37 +128,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(400).json({ error: 'XML content too large (max 1MB)' });
     }
 
+    // Require Nostr authentication — it's the only way to manage the feed later
+    const authHeader = req.headers['authorization'] as string | undefined;
+    const nostrAuth = await parseFeedAuthHeader(authHeader);
+    if (!nostrAuth.valid || !nostrAuth.pubkey) {
+      return res.status(401).json({ error: 'Nostr authentication required to host a feed' });
+    }
+    const ownerPubkey = nostrAuth.pubkey;
+
     // Use podcast GUID as feed ID (one feed per podcast)
     const feedId = podcastGuid;
 
-    // Check if feed already exists by looking for metadata file
-    // (metadata is what defines a "managed" feed with credentials)
+    // Check if feed already exists
     const { blobs } = await list({ prefix: `feeds/${feedId}.meta.json` });
     const existingMeta = blobs.find(b => b.pathname === `feeds/${feedId}.meta.json`);
     if (existingMeta) {
       return res.status(409).json({
-        error: 'Feed already exists for this podcast. Use your edit token to update it, or use the Restore flow.',
+        error: 'A feed already exists for this podcast. Sign in with the original Nostr key to update it.',
         feedId
       });
-    }
-
-    // Use client-provided token or generate one
-    const editToken = (typeof clientToken === 'string' && clientToken.length >= 32)
-      ? clientToken
-      : generateEditToken();
-    const editTokenHash = hashToken(editToken);
-
-    // Check for Nostr auth - if provided, set owner immediately
-    const authHeader = req.headers['authorization'] as string | undefined;
-    let ownerPubkey: string | undefined;
-    let linkedAt: string | undefined;
-
-    if (authHeader?.startsWith('Nostr ')) {
-      const nostrAuth = await parseFeedAuthHeader(authHeader);
-      if (nostrAuth.valid && nostrAuth.pubkey) {
-        ownerPubkey = nostrAuth.pubkey;
-        linkedAt = Date.now().toString();
-      }
     }
 
     // Store feed XML in Vercel Blob
@@ -186,13 +167,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Notify Podcast Index and get PI ID
     const podcastIndexId = await notifyPodcastIndex(stableUrl, { medium });
 
-    // Store metadata separately (Vercel Blob doesn't support custom metadata)
+    // Store metadata
     await put(`feeds/${feedId}.meta.json`, JSON.stringify({
-      editTokenHash,
       createdAt: Date.now().toString(),
       title: (typeof title === 'string' ? title : 'Untitled Feed').slice(0, 200),
       ownerPubkey,
-      linkedAt,
+      linkedAt: Date.now().toString(),
       podcastIndexId
     }), {
       access: 'public',
@@ -203,7 +183,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     return res.status(201).json({
       feedId,
-      editToken, // Only returned once at creation!
       url: stableUrl,
       blobUrl: blob.url,
       podcastIndexId

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,10 @@ import { ThemeProvider, useTheme } from './store/themeStore.tsx';
 import { ExperimentalProvider, useExperimental } from './store/experimentalStore.tsx';
 import { parseRssFeed, isPublisherFeed, isVideoFeed, parsePublisherRssFeed } from './utils/xmlParser';
 import { createEmptyAlbum, createEmptyPublisherFeed, createEmptyVideoAlbum } from './types/feed';
-import { pendingHostedStorage } from './utils/storage';
+import { pendingHostedStorage, wizardStorage } from './utils/storage';
 import { generateTestAlbum } from './utils/testData';
 import { NostrLoginButton } from './components/NostrLoginButton';
+import { ArtistOnboardingWizard } from './components/ArtistOnboardingWizard';
 import { ImportModal } from './components/modals/ImportModal';
 import { SaveModal } from './components/modals/SaveModal';
 import { PreviewModal } from './components/modals/PreviewModal';
@@ -38,6 +39,7 @@ function AppContent() {
   const [showNewFeedChoiceModal, setShowNewFeedChoiceModal] = useState(false);
   const [pendingNewFeedType, setPendingNewFeedType] = useState<FeedType>('album');
   const [isTemplateMode, setIsTemplateMode] = useState(false);
+  const [showArtistWizard, setShowArtistWizard] = useState(() => !wizardStorage.isComplete());
   const [showDropdown, setShowDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { state: nostrState, logout: nostrLogout } = useNostr();
@@ -383,7 +385,15 @@ function AppContent() {
         onStartBlank={handleStartBlank}
         onUseTemplate={handleUseTemplate}
         onCancel={() => setShowNewFeedChoiceModal(false)}
+        onNewArtist={() => { setShowNewFeedChoiceModal(false); setShowArtistWizard(true); }}
       />
+
+      {showArtistWizard && (
+        <ArtistOnboardingWizard
+          onComplete={() => setShowArtistWizard(false)}
+          onOpenLogin={() => setShowNostrConnectModal(true)}
+        />
+      )}
     </>
   );
 }

--- a/src/components/ArtistOnboardingWizard.tsx
+++ b/src/components/ArtistOnboardingWizard.tsx
@@ -25,11 +25,16 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
   const [bunkerUri, setBunkerUri] = useState('');
   const [loginError, setLoginError] = useState('');
 
-  // Step 2 — names
+  // Step 2 — album info
   const [artistName, setArtistName] = useState('');
   const [albumName, setAlbumName] = useState('');
+  const [description, setDescription] = useState('');
+  const [language, setLanguage] = useState('en');
+  const [website, setWebsite] = useState('');
 
-  // Step 3 — upload
+  // Step 3 — upload + track info
+  const [trackTitle, setTrackTitle] = useState('');
+  const [trackDuration, setTrackDuration] = useState('');
   const [audioUrl, setAudioUrl] = useState('');
   const [audioMimeType, setAudioMimeType] = useState('audio/mpeg');
   const [artworkUrl, setArtworkUrl] = useState('');
@@ -94,6 +99,11 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
       if (result.success && result.url) {
         setAudioUrl(result.url);
         setAudioMimeType(file.type || 'audio/mpeg');
+        // Pre-fill track title from filename if not already set
+        if (!trackTitle) {
+          const name = file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ');
+          setTrackTitle(name);
+        }
       } else {
         setAudioUploadError(result.message);
       }
@@ -139,13 +149,17 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
       podcastGuid: albumGuid,
       title: albumName,
       author: artistName,
-      image: artworkUrl,
+      description,
+      language: language || 'en',
+      link: website,
+      imageUrl: artworkUrl,
       publisher: { feedGuid: publisherGuid, feedUrl: '' },
       tracks: [{
         ...createEmptyTrack(1),
-        title: albumName,
+        title: trackTitle || albumName,
         enclosureUrl: audioUrl,
         enclosureType: audioMimeType,
+        duration: trackDuration,
         guid: crypto.randomUUID(),
       }],
     };
@@ -155,6 +169,9 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
       podcastGuid: publisherGuid,
       title: artistName,
       author: artistName,
+      description,
+      language: language || 'en',
+      link: website,
       remoteItems: [{ ...createEmptyRemoteItem(), feedGuid: albumGuid }],
     };
 
@@ -167,14 +184,14 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
         album,
         publisherFeed,
         nostrState.user.npub,
-        (step) => setPublishSteps(prev => {
-          const idx = prev.findIndex(s => s.id === step.id);
+        (s) => setPublishSteps(prev => {
+          const idx = prev.findIndex(p => p.id === s.id);
           if (idx >= 0) {
             const next = [...prev];
-            next[idx] = step;
+            next[idx] = s;
             return next;
           }
-          return [...prev, step];
+          return [...prev, s];
         })
       );
 
@@ -272,15 +289,18 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
     </div>
   );
 
-  // ── Step 2 — Names ─────────────────────────────────────────────────────────
+  // ── Step 2 — Album Info ────────────────────────────────────────────────────
 
   const step2 = (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
       <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
-        What are you releasing?
+        Tell us about your release. Fields marked <span style={{ color: 'var(--error, #dc2626)' }}>*</span> are required.
       </p>
+
       <div className="form-group">
-        <label className="form-label">Artist / Band Name</label>
+        <label className="form-label">
+          Artist / Band Name <span style={{ color: 'var(--error, #dc2626)' }}>*</span>
+        </label>
         <input
           className="form-input"
           placeholder="e.g. The Midnight"
@@ -289,20 +309,62 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
           autoFocus
         />
       </div>
+
       <div className="form-group">
-        <label className="form-label">Album Name</label>
+        <label className="form-label">
+          Album Name <span style={{ color: 'var(--error, #dc2626)' }}>*</span>
+        </label>
         <input
           className="form-input"
           placeholder="e.g. Monsters"
           value={albumName}
           onChange={e => setAlbumName(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter' && artistName.trim() && albumName.trim()) setStep(3); }}
         />
+      </div>
+
+      <div className="form-group">
+        <label className="form-label">
+          Description <span style={{ color: 'var(--error, #dc2626)' }}>*</span>
+        </label>
+        <textarea
+          className="form-input"
+          placeholder="What is this album about? A few sentences is plenty."
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          rows={3}
+          style={{ resize: 'vertical' }}
+        />
+      </div>
+
+      <div style={{ display: 'flex', gap: 12 }}>
+        <div className="form-group" style={{ flex: '0 0 100px' }}>
+          <label className="form-label">
+            Language <span style={{ color: 'var(--error, #dc2626)' }}>*</span>
+          </label>
+          <input
+            className="form-input"
+            placeholder="en"
+            value={language}
+            onChange={e => setLanguage(e.target.value)}
+            maxLength={10}
+          />
+        </div>
+        <div className="form-group" style={{ flex: 1 }}>
+          <label className="form-label">Website <span style={{ color: 'var(--text-secondary)', fontWeight: 'normal' }}>(optional)</span></label>
+          <input
+            className="form-input"
+            placeholder="https://yoursite.com"
+            value={website}
+            onChange={e => setWebsite(e.target.value)}
+          />
+        </div>
       </div>
     </div>
   );
 
-  // ── Step 3 — Upload ────────────────────────────────────────────────────────
+  const step2Valid = artistName.trim() && albumName.trim() && description.trim() && language.trim();
+
+  // ── Step 3 — Upload + Track Info ───────────────────────────────────────────
 
   const step3 = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
@@ -312,7 +374,9 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
 
       {/* Audio upload */}
       <div>
-        <label className="form-label">Audio track</label>
+        <label className="form-label">
+          Audio file <span style={{ color: 'var(--error, #dc2626)' }}>*</span>
+        </label>
         <input
           type="file"
           accept="audio/*"
@@ -328,25 +392,47 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
         {audioUploadError && (
           <div style={{ marginTop: 4, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
             <span style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em' }}>{audioUploadError}</span>
-            <button
-              type="button"
-              className="btn btn-secondary btn-small"
-              onClick={handleRetryAudio}
-            >
+            <button type="button" className="btn btn-secondary btn-small" onClick={handleRetryAudio}>
               Retry
             </button>
           </div>
         )}
         {audioUrl && !uploadingAudio && (
-          <div style={{ color: 'var(--success, #16a34a)', fontSize: '0.85em', marginTop: 4 }}>
-            ✓ Uploaded
-          </div>
+          <div style={{ color: 'var(--success, #16a34a)', fontSize: '0.85em', marginTop: 4 }}>✓ Uploaded</div>
         )}
       </div>
 
+      {/* Track metadata (shown once audio is uploaded) */}
+      {(audioUrl || uploadingAudio) && (
+        <div style={{ display: 'flex', gap: 12 }}>
+          <div className="form-group" style={{ flex: 1 }}>
+            <label className="form-label">
+              Track Title <span style={{ color: 'var(--error, #dc2626)' }}>*</span>
+            </label>
+            <input
+              className="form-input"
+              placeholder="e.g. Track 1"
+              value={trackTitle}
+              onChange={e => setTrackTitle(e.target.value)}
+            />
+          </div>
+          <div className="form-group" style={{ flex: '0 0 110px' }}>
+            <label className="form-label">Duration <span style={{ color: 'var(--text-secondary)', fontWeight: 'normal' }}>(optional)</span></label>
+            <input
+              className="form-input"
+              placeholder="0:00:00"
+              value={trackDuration}
+              onChange={e => setTrackDuration(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Artwork upload */}
       <div>
-        <label className="form-label">Album artwork <span style={{ color: 'var(--text-secondary)', fontWeight: 'normal' }}>(optional)</span></label>
+        <label className="form-label">
+          Album artwork <span style={{ color: 'var(--text-secondary)', fontWeight: 'normal' }}>(optional — required for most podcast apps)</span>
+        </label>
         <input
           type="file"
           accept="image/*"
@@ -363,13 +449,16 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
           <div style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em', marginTop: 4 }}>{artworkUploadError}</div>
         )}
         {artworkUrl && !uploadingArtwork && (
-          <div style={{ color: 'var(--success, #16a34a)', fontSize: '0.85em', marginTop: 4 }}>
-            ✓ Uploaded
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 4 }}>
+            <img src={artworkUrl} alt="Artwork preview" style={{ width: 48, height: 48, objectFit: 'cover', borderRadius: 4 }} />
+            <span style={{ color: 'var(--success, #16a34a)', fontSize: '0.85em' }}>✓ Uploaded</span>
           </div>
         )}
       </div>
     </div>
   );
+
+  const step3Valid = audioUrl && !uploadingAudio && !uploadingArtwork && trackTitle.trim();
 
   // ── Step 4 — Publish ───────────────────────────────────────────────────────
 
@@ -395,17 +484,20 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
             background: 'var(--bg-secondary, #f5f5f5)',
             fontSize: '0.9em',
             display: 'flex',
-            flexDirection: 'column',
-            gap: 4,
+            gap: 12,
+            alignItems: 'flex-start',
           }}>
-            <strong>{artistName}</strong>
-            <span style={{ color: 'var(--text-secondary)' }}>{albumName}</span>
             {artworkUrl && (
-              <img src={artworkUrl} alt="Album art" style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 4, marginTop: 4 }} />
+              <img src={artworkUrl} alt="Album art" style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 4, flexShrink: 0 }} />
             )}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <strong>{albumName}</strong>
+              <span style={{ color: 'var(--text-secondary)' }}>by {artistName}</span>
+              <span style={{ color: 'var(--text-secondary)', fontSize: '0.9em' }}>{trackTitle} · {language.toUpperCase()}</span>
+            </div>
           </div>
           <p style={{ color: 'var(--text-secondary)', margin: 0, fontSize: '0.9em' }}>
-            MSP will host your album feed and create a publisher catalog — both linked together and submitted to Podcast Index automatically.
+            MSP will host your album feed and a publisher catalog — both cross-linked and submitted to Podcast Index automatically.
           </p>
           {publishSteps.length > 0 && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -474,7 +566,7 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
         <button
           className="btn btn-primary"
           onClick={() => setStep(3)}
-          disabled={!artistName.trim() || !albumName.trim()}
+          disabled={!step2Valid}
         >
           Next
         </button>
@@ -483,7 +575,7 @@ export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboar
         <button
           className="btn btn-primary"
           onClick={() => setStep(4)}
-          disabled={!audioUrl || uploadingAudio || uploadingArtwork}
+          disabled={!step3Valid}
         >
           Next: Publish
         </button>

--- a/src/components/ArtistOnboardingWizard.tsx
+++ b/src/components/ArtistOnboardingWizard.tsx
@@ -1,0 +1,541 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNostr } from '../store/nostrStore';
+import { useFeed } from '../store/feedStore';
+import { createEmptyAlbum, createEmptyTrack, createEmptyPublisherFeed, createEmptyRemoteItem } from '../types/feed';
+import { wizardStorage } from '../utils/storage';
+import { uploadMediaToBlossom } from '../utils/blossom';
+import { hostBothOnMSP } from '../utils/artistPublish';
+import type { PublishStep } from '../utils/artistPublish';
+import { ModalWrapper } from './modals/ModalWrapper';
+
+interface ArtistOnboardingWizardProps {
+  onComplete: () => void;
+  onOpenLogin: () => void;
+}
+
+const STEP_LABELS = ['Login', 'Your Info', 'Upload Music', 'Publish'];
+
+export function ArtistOnboardingWizard({ onComplete, onOpenLogin }: ArtistOnboardingWizardProps) {
+  const { state: nostrState, login, loginWithNip46 } = useNostr();
+  const { dispatch } = useFeed();
+
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(() => (nostrState.isLoggedIn ? 2 : 1));
+
+  // Step 1 — login
+  const [bunkerUri, setBunkerUri] = useState('');
+  const [loginError, setLoginError] = useState('');
+
+  // Step 2 — names
+  const [artistName, setArtistName] = useState('');
+  const [albumName, setAlbumName] = useState('');
+
+  // Step 3 — upload
+  const [audioUrl, setAudioUrl] = useState('');
+  const [audioMimeType, setAudioMimeType] = useState('audio/mpeg');
+  const [artworkUrl, setArtworkUrl] = useState('');
+  const [uploadingAudio, setUploadingAudio] = useState(false);
+  const [uploadingArtwork, setUploadingArtwork] = useState(false);
+  const [audioUploadError, setAudioUploadError] = useState('');
+  const [artworkUploadError, setArtworkUploadError] = useState('');
+  const lastAudioFile = useRef<File | null>(null);
+
+  // Step 4 — publish
+  const [publishing, setPublishing] = useState(false);
+  const [publishSteps, setPublishSteps] = useState<PublishStep[]>([]);
+  const [publishError, setPublishError] = useState('');
+  const [albumFeedUrl, setAlbumFeedUrl] = useState('');
+
+  // Auto-advance past step 1 when login completes
+  useEffect(() => {
+    if (nostrState.isLoggedIn && step === 1) {
+      setLoginError('');
+      setStep(2);
+    }
+  }, [nostrState.isLoggedIn, step]);
+
+  const handleDismiss = () => {
+    wizardStorage.markComplete();
+    onComplete();
+  };
+
+  // ── Step 1 handlers ──────────────────────────────────────────────────────────
+
+  const handleExtensionLogin = async () => {
+    setLoginError('');
+    try {
+      await login();
+    } catch (e) {
+      setLoginError(e instanceof Error ? e.message : 'Login failed');
+    }
+  };
+
+  const handleBunkerLogin = async () => {
+    const uri = bunkerUri.trim();
+    if (!uri) return;
+    setLoginError('');
+    try {
+      await loginWithNip46(uri);
+    } catch (e) {
+      setLoginError(e instanceof Error ? e.message : 'Login failed');
+    }
+  };
+
+  // ── Step 3 handlers ──────────────────────────────────────────────────────────
+
+  const handleAudioChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    lastAudioFile.current = file;
+    setAudioUploadError('');
+    setUploadingAudio(true);
+    try {
+      const result = await uploadMediaToBlossom(file);
+      if (result.success && result.url) {
+        setAudioUrl(result.url);
+        setAudioMimeType(file.type || 'audio/mpeg');
+      } else {
+        setAudioUploadError(result.message);
+      }
+    } finally {
+      setUploadingAudio(false);
+    }
+  };
+
+  const handleArtworkChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setArtworkUploadError('');
+    setUploadingArtwork(true);
+    try {
+      const result = await uploadMediaToBlossom(file);
+      if (result.success && result.url) {
+        setArtworkUrl(result.url);
+      } else {
+        setArtworkUploadError(result.message);
+      }
+    } finally {
+      setUploadingArtwork(false);
+    }
+  };
+
+  const handleRetryAudio = () => {
+    const file = lastAudioFile.current;
+    if (!file) return;
+    handleAudioChange({ target: { files: [file], value: '' } } as unknown as React.ChangeEvent<HTMLInputElement>);
+  };
+
+  // ── Step 4 handler ──────────────────────────────────────────────────────────
+
+  const handlePublish = async () => {
+    if (!nostrState.user?.npub) return;
+
+    const albumGuid = crypto.randomUUID();
+    const publisherGuid = crypto.randomUUID();
+
+    const album = {
+      ...createEmptyAlbum(),
+      podcastGuid: albumGuid,
+      title: albumName,
+      author: artistName,
+      image: artworkUrl,
+      publisher: { feedGuid: publisherGuid, feedUrl: '' },
+      tracks: [{
+        ...createEmptyTrack(1),
+        title: albumName,
+        enclosureUrl: audioUrl,
+        enclosureType: audioMimeType,
+        guid: crypto.randomUUID(),
+      }],
+    };
+
+    const publisherFeed = {
+      ...createEmptyPublisherFeed(),
+      podcastGuid: publisherGuid,
+      title: artistName,
+      author: artistName,
+      remoteItems: [{ ...createEmptyRemoteItem(), feedGuid: albumGuid }],
+    };
+
+    setPublishError('');
+    setPublishing(true);
+    setPublishSteps([]);
+
+    try {
+      const result = await hostBothOnMSP(
+        album,
+        publisherFeed,
+        nostrState.user.npub,
+        (step) => setPublishSteps(prev => {
+          const idx = prev.findIndex(s => s.id === step.id);
+          if (idx >= 0) {
+            const next = [...prev];
+            next[idx] = step;
+            return next;
+          }
+          return [...prev, step];
+        })
+      );
+
+      dispatch({ type: 'SET_PUBLISHER_FEED', payload: result.patchedPublisherFeed });
+      dispatch({ type: 'SET_ALBUM', payload: result.patchedAlbum });
+
+      setAlbumFeedUrl(result.album.url);
+      wizardStorage.markComplete();
+    } catch (e) {
+      setPublishError(e instanceof Error ? e.message : 'Publishing failed');
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  // ── Step progress dots ───────────────────────────────────────────────────────
+
+  const progressDots = (
+    <div style={{ display: 'flex', gap: 6, alignItems: 'center', justifyContent: 'center' }}>
+      {([1, 2, 3, 4] as const).map(n => (
+        <div
+          key={n}
+          title={STEP_LABELS[n - 1]}
+          style={{
+            width: 10, height: 10, borderRadius: '50%',
+            background: n === step
+              ? 'var(--accent-primary, #7c3aed)'
+              : n < step
+                ? 'var(--success, #16a34a)'
+                : 'var(--border-color, #ccc)',
+            transition: 'background 0.2s',
+          }}
+        />
+      ))}
+      <span style={{ fontSize: '0.8em', color: 'var(--text-secondary)', marginLeft: 8 }}>
+        Step {step} of 4 — {STEP_LABELS[step - 1]}
+      </span>
+    </div>
+  );
+
+  // ── Step 1 — Login ─────────────────────────────────────────────────────────
+
+  const step1 = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+        MSP uses Nostr for authentication. Login once and your feeds are linked to your identity.
+      </p>
+      {nostrState.hasExtension && (
+        <button
+          className="btn btn-primary"
+          onClick={handleExtensionLogin}
+          disabled={nostrState.isLoading}
+          style={{ width: '100%' }}
+        >
+          {nostrState.isLoading ? 'Connecting…' : 'Connect with Browser Extension'}
+        </button>
+      )}
+      <div>
+        <label className="form-label">Remote signer (Amber, nsecBunker)</label>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <input
+            className="form-input"
+            style={{ flex: 1 }}
+            placeholder="bunker://..."
+            value={bunkerUri}
+            onChange={e => setBunkerUri(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleBunkerLogin(); }}
+          />
+          <button
+            className="btn btn-primary"
+            onClick={handleBunkerLogin}
+            disabled={!bunkerUri.trim() || nostrState.isLoading}
+          >
+            Connect
+          </button>
+        </div>
+      </div>
+      {!nostrState.hasExtension && (
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.85em', margin: 0 }}>
+          Or install a Nostr browser extension (Alby, nos2x) to connect with one click.
+        </p>
+      )}
+      {(loginError || nostrState.error) && (
+        <div style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em' }}>
+          {loginError || nostrState.error}
+        </div>
+      )}
+      <button
+        className="btn btn-link"
+        onClick={onOpenLogin}
+        style={{ textAlign: 'left', padding: 0, fontSize: '0.85em', color: 'var(--text-secondary)' }}
+      >
+        More login options →
+      </button>
+    </div>
+  );
+
+  // ── Step 2 — Names ─────────────────────────────────────────────────────────
+
+  const step2 = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+        What are you releasing?
+      </p>
+      <div className="form-group">
+        <label className="form-label">Artist / Band Name</label>
+        <input
+          className="form-input"
+          placeholder="e.g. The Midnight"
+          value={artistName}
+          onChange={e => setArtistName(e.target.value)}
+          autoFocus
+        />
+      </div>
+      <div className="form-group">
+        <label className="form-label">Album Name</label>
+        <input
+          className="form-input"
+          placeholder="e.g. Monsters"
+          value={albumName}
+          onChange={e => setAlbumName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && artistName.trim() && albumName.trim()) setStep(3); }}
+        />
+      </div>
+    </div>
+  );
+
+  // ── Step 3 — Upload ────────────────────────────────────────────────────────
+
+  const step3 = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <p style={{ color: 'var(--text-secondary)', margin: 0 }}>
+        Upload your audio and artwork directly to Blossom — no hosting account needed.
+      </p>
+
+      {/* Audio upload */}
+      <div>
+        <label className="form-label">Audio track</label>
+        <input
+          type="file"
+          accept="audio/*"
+          disabled={uploadingAudio}
+          style={{ display: 'block', width: '100%' }}
+          onChange={handleAudioChange}
+        />
+        {uploadingAudio && (
+          <div style={{ color: 'var(--text-secondary)', fontSize: '0.85em', marginTop: 4 }}>
+            Uploading to Blossom servers…
+          </div>
+        )}
+        {audioUploadError && (
+          <div style={{ marginTop: 4, display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em' }}>{audioUploadError}</span>
+            <button
+              type="button"
+              className="btn btn-secondary btn-small"
+              onClick={handleRetryAudio}
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {audioUrl && !uploadingAudio && (
+          <div style={{ color: 'var(--success, #16a34a)', fontSize: '0.85em', marginTop: 4 }}>
+            ✓ Uploaded
+          </div>
+        )}
+      </div>
+
+      {/* Artwork upload */}
+      <div>
+        <label className="form-label">Album artwork <span style={{ color: 'var(--text-secondary)', fontWeight: 'normal' }}>(optional)</span></label>
+        <input
+          type="file"
+          accept="image/*"
+          disabled={uploadingArtwork}
+          style={{ display: 'block', width: '100%' }}
+          onChange={handleArtworkChange}
+        />
+        {uploadingArtwork && (
+          <div style={{ color: 'var(--text-secondary)', fontSize: '0.85em', marginTop: 4 }}>
+            Uploading to Blossom servers…
+          </div>
+        )}
+        {artworkUploadError && (
+          <div style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em', marginTop: 4 }}>{artworkUploadError}</div>
+        )}
+        {artworkUrl && !uploadingArtwork && (
+          <div style={{ color: 'var(--success, #16a34a)', fontSize: '0.85em', marginTop: 4 }}>
+            ✓ Uploaded
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  // ── Step 4 — Publish ───────────────────────────────────────────────────────
+
+  const stepStatusIcon = (status: PublishStep['status']) => {
+    if (status === 'done') return <span style={{ color: 'var(--success, #16a34a)' }}>✓</span>;
+    if (status === 'in-progress') return <span style={{ color: 'var(--text-secondary)' }}>⋯</span>;
+    if (status === 'failed') return <span style={{ color: 'var(--error, #dc2626)' }}>✗</span>;
+    return <span style={{ color: 'var(--text-secondary)' }}>○</span>;
+  };
+
+  const stepLabels: Record<string, string> = {
+    'album-host': 'Hosting album feed',
+    'publisher-host': 'Hosting publisher catalog',
+  };
+
+  const step4 = (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {!albumFeedUrl && (
+        <>
+          <div style={{
+            padding: '12px 16px',
+            borderRadius: 8,
+            background: 'var(--bg-secondary, #f5f5f5)',
+            fontSize: '0.9em',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 4,
+          }}>
+            <strong>{artistName}</strong>
+            <span style={{ color: 'var(--text-secondary)' }}>{albumName}</span>
+            {artworkUrl && (
+              <img src={artworkUrl} alt="Album art" style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 4, marginTop: 4 }} />
+            )}
+          </div>
+          <p style={{ color: 'var(--text-secondary)', margin: 0, fontSize: '0.9em' }}>
+            MSP will host your album feed and create a publisher catalog — both linked together and submitted to Podcast Index automatically.
+          </p>
+          {publishSteps.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {publishSteps.map(s => (
+                <div key={s.id} style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: '0.9em' }}>
+                  {stepStatusIcon(s.status)}
+                  <span>{stepLabels[s.id] || s.id}</span>
+                  {s.message && <span style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em' }}>{s.message}</span>}
+                </div>
+              ))}
+            </div>
+          )}
+          {publishError && (
+            <div style={{ color: 'var(--error, #dc2626)', fontSize: '0.85em' }}>{publishError}</div>
+          )}
+        </>
+      )}
+
+      {albumFeedUrl && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <div style={{ color: 'var(--success, #16a34a)', fontWeight: 600, fontSize: '1.05em' }}>
+            🎉 Your feed is live!
+          </div>
+          <div>
+            <label className="form-label">Feed URL (for podcast apps)</label>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <input
+                className="form-input"
+                readOnly
+                value={albumFeedUrl}
+                style={{ flex: 1, fontSize: '0.85em' }}
+                onFocus={e => e.target.select()}
+              />
+              <button
+                className="btn btn-secondary btn-small"
+                onClick={() => navigator.clipboard.writeText(albumFeedUrl)}
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.85em', margin: 0 }}>
+            Use this URL in Fountain, Castamatic, Apple Podcasts, or any Podcasting 2.0 app to listen and support you with streaming payments.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+
+  // ── Footer buttons ─────────────────────────────────────────────────────────
+
+  const footer = (
+    <div style={{ display: 'flex', gap: 12, width: '100%', alignItems: 'center' }}>
+      {step === 3 && (
+        <button className="btn btn-secondary" onClick={() => setStep(2)}>
+          Back
+        </button>
+      )}
+      {step === 4 && !albumFeedUrl && (
+        <button className="btn btn-secondary" onClick={() => setStep(3)} disabled={publishing}>
+          Back
+        </button>
+      )}
+
+      {step === 2 && (
+        <button
+          className="btn btn-primary"
+          onClick={() => setStep(3)}
+          disabled={!artistName.trim() || !albumName.trim()}
+        >
+          Next
+        </button>
+      )}
+      {step === 3 && (
+        <button
+          className="btn btn-primary"
+          onClick={() => setStep(4)}
+          disabled={!audioUrl || uploadingAudio || uploadingArtwork}
+        >
+          Next: Publish
+        </button>
+      )}
+      {step === 4 && !albumFeedUrl && (
+        <button
+          className="btn btn-primary"
+          onClick={handlePublish}
+          disabled={publishing}
+          style={{ minWidth: 140 }}
+        >
+          {publishing ? 'Publishing…' : publishError ? 'Retry' : 'Host on MSP'}
+        </button>
+      )}
+      {albumFeedUrl && (
+        <button className="btn btn-primary" onClick={onComplete}>
+          Open in Editor →
+        </button>
+      )}
+
+      <div style={{ flex: 1 }} />
+
+      {!albumFeedUrl && (
+        <button
+          className="btn btn-secondary"
+          onClick={handleDismiss}
+          title="Skip wizard and go to editor"
+        >
+          Skip
+        </button>
+      )}
+    </div>
+  );
+
+  // ── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <ModalWrapper
+      isOpen={true}
+      onClose={handleDismiss}
+      title={
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <span>New Artist Setup</span>
+          {progressDots}
+        </div>
+      }
+      footer={footer}
+    >
+      {step === 1 && step1}
+      {step === 2 && step2}
+      {step === 3 && step3}
+      {step === 4 && step4}
+    </ModalWrapper>
+  );
+}

--- a/src/components/BlossomFileUpload.tsx
+++ b/src/components/BlossomFileUpload.tsx
@@ -1,0 +1,99 @@
+import { useState, useRef } from 'react';
+import { useNostr } from '../store/nostrStore';
+import { uploadMediaToBlossom } from '../utils/blossom';
+
+interface BlossomFileUploadProps {
+  accept: string;
+  onUploaded: (result: { url: string; file: File }) => void;
+  label?: string;
+}
+
+export function BlossomFileUpload({ accept, onUploaded, label = 'Upload to Blossom' }: BlossomFileUploadProps) {
+  const { state: nostrState } = useNostr();
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [partial, setPartial] = useState<{ succeeded: number; total: number } | null>(null);
+  const lastFileRef = useRef<File | null>(null);
+
+  // The URL field above this control is enough for logged-out users.
+  if (!nostrState.isLoggedIn) return null;
+
+  const doUpload = async (file: File) => {
+    lastFileRef.current = file;
+    setUploading(true);
+    setError(null);
+    setSuccess(false);
+    setPartial(null);
+    try {
+      const result = await uploadMediaToBlossom(file);
+      if (result.success && result.url) {
+        onUploaded({ url: result.url, file });
+        setSuccess(true);
+        if (result.serversSucceeded < result.serversTotal) {
+          setPartial({ succeeded: result.serversSucceeded, total: result.serversTotal });
+        }
+      } else {
+        setError(result.message);
+      }
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    doUpload(file);
+  };
+
+  return (
+    <div style={{ marginTop: '6px' }}>
+      <label className="form-label" style={{ fontSize: '0.85em', marginBottom: '4px' }}>{label}</label>
+      <input
+        type="file"
+        accept={accept}
+        disabled={uploading}
+        style={{ display: 'block', width: '100%', fontSize: '0.9em' }}
+        onChange={handleChange}
+      />
+      {uploading && (
+        <div style={{ color: 'var(--text-secondary)', fontSize: '0.85em', marginTop: '4px' }}>
+          Uploading to Blossom servers…
+        </div>
+      )}
+      {error && (
+        <div style={{ marginTop: '4px', display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}>
+          <span style={{ color: 'var(--error)', fontSize: '0.85em' }}>{error}</span>
+          <button
+            type="button"
+            className="btn-secondary"
+            style={{
+              fontSize: '0.8em',
+              padding: '2px 10px',
+              cursor: 'pointer',
+              border: '1px solid var(--border-color, #ccc)',
+              borderRadius: '4px',
+              background: 'transparent',
+              color: 'inherit',
+            }}
+            onClick={() => { if (lastFileRef.current) doUpload(lastFileRef.current); }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {success && (
+        <div style={{ color: 'var(--success, #2d7a2d)', fontSize: '0.85em', marginTop: '4px' }}>
+          Uploaded — URL filled in
+          {partial && (
+            <span style={{ color: 'var(--text-secondary)' }}>
+              {' '}· Hosted on {partial.succeeded} of {partial.total} servers
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Editor/PublisherEditor/PublishSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublishSection.tsx
@@ -10,7 +10,7 @@ import {
   type PublishProgress,
   type PublishResult
 } from '../../../utils/publisherPublish';
-import { downloadHostedFeedBackup, type HostedFeedInfo } from '../../../utils/hostedFeed';
+import type { HostedFeedInfo } from '../../../utils/hostedFeed';
 import { publisherStorage } from '../../../utils/storage';
 
 interface PublishSectionProps {
@@ -43,8 +43,6 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
   // Options
   const [updateCatalogFeeds, setUpdateCatalogFeeds] = useState(true);
 
-  // Token acknowledgment (for first-time publish)
-  const [tokenAcknowledged, setTokenAcknowledged] = useState(false);
   const [pendingHostedInfo, setPendingHostedInfo] = useState<HostedFeedInfo | null>(null);
 
   // Current status
@@ -98,11 +96,6 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
   }, [progress, updateCatalogFeeds, publisherFeed.remoteItems.length]);
 
   const handlePublish = async () => {
-    // For first-time publish without Nostr, require token acknowledgment
-    if (!isPublished && !isLoggedIn && !tokenAcknowledged) {
-      return;
-    }
-
     // Save to local storage first
     publisherStorage.save(publisherFeed);
 
@@ -179,9 +172,7 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
     navigator.clipboard.writeText(text);
   };
 
-  // Show token save UI for first-time publish when not logged in
-  const showTokenSaveUI = !isPublished && !isLoggedIn && !tokenAcknowledged;
-  const showNewTokenInfo = pendingHostedInfo && !isLoggedIn;
+  const showNewTokenInfo = pendingHostedInfo && isLoggedIn;
 
   return (
     <Section title="Publish on MSP" icon="&#128640;">
@@ -307,103 +298,18 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
         </div>
       )}
 
-      {/* Token Save Warning (first-time publish without Nostr) */}
-      {showTokenSaveUI && (
-        <div style={{
-          marginBottom: '16px',
-          padding: '12px',
-          backgroundColor: 'var(--bg-tertiary)',
-          borderRadius: '8px',
-          border: '1px solid var(--warning-color, #f59e0b)'
-        }}>
-          <p style={{
-            fontSize: '14px',
-            fontWeight: 600,
-            color: 'var(--warning-color, #f59e0b)',
-            marginBottom: '8px'
-          }}>
-            Important: Save your edit token
-          </p>
-          <p style={{ fontSize: '13px', color: 'var(--text-secondary)', marginBottom: '12px' }}>
-            You'll need an edit token to update this feed later. The token will be shown after publishing.
-            Make sure to save it somewhere safe!
-          </p>
-          <label style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            cursor: 'pointer',
-            fontSize: '14px',
-            padding: '8px',
-            backgroundColor: tokenAcknowledged ? 'rgba(16, 185, 129, 0.1)' : 'transparent',
-            borderRadius: '4px',
-            border: tokenAcknowledged ? '1px solid var(--success-color)' : '1px solid var(--border-color)'
-          }}>
-            <input
-              type="checkbox"
-              checked={tokenAcknowledged}
-              onChange={(e) => setTokenAcknowledged(e.target.checked)}
-              style={{ width: '16px', height: '16px' }}
-            />
-            <span>I understand I need to save my edit token</span>
-          </label>
-        </div>
-      )}
-
-      {/* Show new token after first publish */}
+      {/* Confirmation after first publish */}
       {showNewTokenInfo && (
         <div style={{
           marginBottom: '16px',
           padding: '12px',
           backgroundColor: 'var(--bg-tertiary)',
           borderRadius: '8px',
-          border: '1px solid var(--warning-color, #f59e0b)'
+          border: '1px solid var(--success-color)'
         }}>
-          <p style={{
-            fontSize: '14px',
-            fontWeight: 600,
-            color: 'var(--warning-color, #f59e0b)',
-            marginBottom: '8px'
-          }}>
-            Save your edit token now!
+          <p style={{ fontSize: '14px', color: 'var(--success-color)', margin: 0 }}>
+            Feed published and linked to your Nostr identity. You can update it from any device.
           </p>
-          <input
-            type="text"
-            value={pendingHostedInfo.editToken}
-            readOnly
-            onClick={(e) => (e.target as HTMLInputElement).select()}
-            style={{
-              width: '100%',
-              padding: '8px 12px',
-              borderRadius: '4px',
-              border: '1px solid var(--warning-color, #f59e0b)',
-              backgroundColor: 'var(--bg-secondary)',
-              color: 'var(--text-primary)',
-              fontSize: '12px',
-              fontFamily: 'monospace',
-              marginBottom: '12px'
-            }}
-          />
-          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-            <button
-              className="btn btn-secondary"
-              onClick={() => copyToClipboard(pendingHostedInfo.editToken)}
-            >
-              Copy Token
-            </button>
-            <button
-              className="btn btn-secondary"
-              onClick={() => {
-                downloadHostedFeedBackup(
-                  pendingHostedInfo.feedId,
-                  pendingHostedInfo.editToken,
-                  publisherFeed.title || 'Publisher Feed'
-                );
-              }}
-            >
-              Download Backup
-            </button>
-          </div>
         </div>
       )}
 
@@ -426,7 +332,7 @@ export function PublishSection({ publisherFeed }: PublishSectionProps) {
       <button
         className="btn btn-primary"
         onClick={handlePublish}
-        disabled={isPublishing || !canPublish || showTokenSaveUI}
+        disabled={isPublishing || !canPublish}
         style={{
           width: '100%',
           padding: '12px',

--- a/src/components/Editor/PublisherEditor/PublisherFeedReminderSection.tsx
+++ b/src/components/Editor/PublisherEditor/PublisherFeedReminderSection.tsx
@@ -4,14 +4,12 @@ import { getFeedUrlError } from '../../../utils/urlValidation';
 import { Section } from '../../Section';
 import { generatePublisherRssFeed, downloadXml } from '../../../utils/xmlGenerator';
 import {
-  createHostedFeed,
   createHostedFeedWithNostr,
   buildHostedUrl,
-  generateEditToken,
   saveHostedFeedInfo,
   getHostedFeedInfo
 } from '../../../utils/hostedFeed';
-import { hasSigner, checkSignerConnection } from '../../../utils/nostrSigner';
+import { checkSignerConnection } from '../../../utils/nostrSigner';
 import { useNostr } from '../../../store/nostrStore';
 
 interface PublisherFeedReminderSectionProps {
@@ -41,40 +39,24 @@ export function PublisherFeedReminderSection({ publisherFeed }: PublisherFeedRem
     setResult(null);
 
     try {
+      const health = await checkSignerConnection();
+      if (!health.connected) {
+        setResult({ success: false, message: health.error ?? 'Nostr signer is not connected.' });
+        setIsHosting(false);
+        return;
+      }
+
       const xml = generatePublisherRssFeed({ ...publisherFeed, lastBuildDate: new Date().toUTCString() });
       const title = publisherFeed.title || 'Publisher Feed';
-      const editToken = generateEditToken();
-      const shouldLinkNostr = nostrState.isLoggedIn && nostrState.user?.pubkey && hasSigner();
 
-      if (shouldLinkNostr) {
-        const health = await checkSignerConnection();
-        if (!health.connected) {
-          setResult({ success: false, message: health.error ?? 'Nostr signer is not connected.' });
-          setIsHosting(false);
-          return;
-        }
-      }
-
-      let response;
-      if (shouldLinkNostr) {
-        response = await createHostedFeedWithNostr(xml, title, podcastGuid, editToken);
-        saveHostedFeedInfo(podcastGuid, {
-          feedId: response.feedId,
-          editToken,
-          createdAt: Date.now(),
-          lastUpdated: Date.now(),
-          ownerPubkey: nostrState.user?.pubkey,
-          linkedAt: Date.now()
-        });
-      } else {
-        response = await createHostedFeed(xml, title, podcastGuid, editToken);
-        saveHostedFeedInfo(podcastGuid, {
-          feedId: response.feedId,
-          editToken,
-          createdAt: Date.now(),
-          lastUpdated: Date.now()
-        });
-      }
+      const response = await createHostedFeedWithNostr(xml, title, podcastGuid);
+      saveHostedFeedInfo(podcastGuid, {
+        feedId: response.feedId,
+        createdAt: Date.now(),
+        lastUpdated: Date.now(),
+        ownerPubkey: nostrState.user?.pubkey,
+        linkedAt: Date.now()
+      });
 
       const feedUrl = response.url;
 

--- a/src/components/modals/NewFeedChoiceModal.tsx
+++ b/src/components/modals/NewFeedChoiceModal.tsx
@@ -7,6 +7,7 @@ interface NewFeedChoiceModalProps {
   onStartBlank: () => void;
   onUseTemplate: () => void;
   onCancel: () => void;
+  onNewArtist?: () => void;
 }
 
 const feedTypeLabel = (feedType: FeedType) =>
@@ -18,6 +19,7 @@ export function NewFeedChoiceModal({
   onStartBlank,
   onUseTemplate,
   onCancel,
+  onNewArtist,
 }: NewFeedChoiceModalProps) {
   const label = feedTypeLabel(feedType);
 
@@ -27,11 +29,16 @@ export function NewFeedChoiceModal({
       onClose={onCancel}
       title={`New ${label}`}
       footer={
-        <div style={{ display: 'flex', gap: '12px', width: '100%' }}>
+        <div style={{ display: 'flex', gap: '12px', width: '100%', flexWrap: 'wrap' }}>
+          {onNewArtist && feedType === 'album' && (
+            <button className="btn btn-primary" onClick={onNewArtist}>
+              New Artist (Guided)
+            </button>
+          )}
           <button className="btn btn-warning" onClick={onStartBlank}>
             Start Blank
           </button>
-          <button className="btn btn-primary" onClick={onUseTemplate}>
+          <button className="btn btn-secondary" onClick={onUseTemplate}>
             Use Template
           </button>
           <div style={{ flex: 1 }} />

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -10,17 +10,12 @@ import {
   getHostedFeedInfo,
   saveHostedFeedInfo,
   clearHostedFeedInfo,
-  createHostedFeed,
-  updateHostedFeed,
   buildHostedUrl,
-  downloadHostedFeedBackup,
-  generateEditToken,
   createHostedFeedWithNostr,
   updateHostedFeedWithNostr,
-  linkNostrToFeed,
   type HostedFeedInfo
 } from '../../utils/hostedFeed';
-import { albumStorage, videoStorage, publisherStorage, pendingHostedStorage } from '../../utils/storage';
+import { albumStorage, videoStorage, publisherStorage } from '../../utils/storage';
 import { useNostr } from '../../store/nostrStore';
 import { useExperimental } from '../../store/experimentalStore';
 import { checkSignerConnection } from '../../utils/nostrSigner';
@@ -39,7 +34,7 @@ interface SaveModalProps {
   onImport?: (xml: string) => void;
 }
 
-export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', isDirty, isLoggedIn, onImport }: SaveModalProps) {
+export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', isDirty, isLoggedIn }: SaveModalProps) {
   const { state: nostrState } = useNostr();
   const { showExperimental } = useExperimental();
   const [mode, setMode] = useState<'local' | 'download' | 'clipboard' | 'nostr' | 'nostrMusic' | 'blossom' | 'nsite' | 'hosted' | 'podcastIndex'>('local');
@@ -68,15 +63,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   const [stableUrl, setStableUrl] = useState<string | null>(null);
   const [hostedInfo, setHostedInfo] = useState<HostedFeedInfo | null>(null);
   const [hostedUrl, setHostedUrl] = useState<string | null>(null);
-  const [legacyHostedInfo, setLegacyHostedInfo] = useState<HostedFeedInfo | null>(null); // For feeds with mismatched feedId
-  const [showRestore, setShowRestore] = useState(false);
-  const [restoreFeedId, setRestoreFeedId] = useState('');
-  const [restoreToken, setRestoreToken] = useState('');
-  const [restoreLoading, setRestoreLoading] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
-  const [pendingToken, setPendingToken] = useState<string | null>(null);
-  const [tokenAcknowledged, setTokenAcknowledged] = useState(false);
-  const [linkingNostr, setLinkingNostr] = useState(false);
   const [podcastIndexPending, setPodcastIndexPending] = useState(false); // True when PI notified but not yet indexed
   const nsiteSiteId = defaultSiteId(currentFeedGuid);
   const [nsiteUrl, setNsiteUrl] = useState<string | null>(null);
@@ -86,8 +73,8 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   const [podcastIndexSubmitUrl, setPodcastIndexSubmitUrl] = useState('');
   const [podcastIndexResultUrl, setPodcastIndexResultUrl] = useState<string | null>(null);
 
-  // Check if feed is linked to current user's Nostr identity
-  const isNostrLinked = hostedInfo?.ownerPubkey && nostrState.user?.pubkey === hostedInfo.ownerPubkey;
+  // Check if feed is owned by current Nostr user
+  const isNostrOwner = hostedInfo?.ownerPubkey && nostrState.user?.pubkey === hostedInfo.ownerPubkey;
 
   // Helper to get button text based on mode and loading state
   const getButtonText = () => {
@@ -111,17 +98,10 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   // Helper to determine if button should be disabled
   const isButtonDisabled = () => {
     if (loading) return true;
-    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !tokenAcknowledged) return true;
+    if (mode === 'hosted' && !isLoggedIn) return true;
     if (mode === 'podcastIndex' && (!podcastIndexSubmitUrl.trim() || !!podcastIndexUrlError)) return true;
     return false;
   };
-
-  // Generate token when selecting hosted mode for a new feed
-  useEffect(() => {
-    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !pendingToken && !showRestore) {
-      setPendingToken(generateEditToken());
-    }
-  }, [mode, hostedInfo, legacyHostedInfo, pendingToken, showRestore]);
 
   // Reset mode if the current selection is an experimental option that just got hidden
   useEffect(() => {
@@ -138,129 +118,15 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
     if (url) setPodcastIndexSubmitUrl(url);
   }, [mode, hostedUrl, stableUrl, nsiteUrl, podcastIndexSubmitUrl]);
 
-  // Check for existing hosted feed on mount, and apply pending credentials
+  // Check for existing hosted feed info on mount
   useEffect(() => {
     if (!currentFeedGuid) return;
-
-    // Check for pending credentials from import
-    const pending = pendingHostedStorage.load();
-    if (pending) {
-      // Only use pending credentials if they match the current feed's GUID
-      if (pending.feedId === currentFeedGuid) {
-        saveHostedFeedInfo(currentFeedGuid, pending);
-        pendingHostedStorage.clear();
-        setHostedInfo(pending);
-        setHostedUrl(buildHostedUrl(pending.feedId));
-        return;
-      } else {
-        // Pending credentials don't match current feed - discard them
-        // (They're stale from a previous import, not a legacy migration)
-        pendingHostedStorage.clear();
-      }
-    }
-
     const info = getHostedFeedInfo(currentFeedGuid);
     if (info) {
-      // Check if feedId matches podcastGuid (legacy feeds may have different IDs)
-      if (info.feedId === currentFeedGuid) {
-        setHostedInfo(info);
-        setHostedUrl(buildHostedUrl(info.feedId));
-      } else {
-        // Legacy feed with mismatched ID - keep it to update both URLs on save
-        setLegacyHostedInfo(info);
-        // Show the correct URL (podcastGuid) as the primary
-        setHostedUrl(buildHostedUrl(currentFeedGuid));
-      }
+      setHostedInfo(info);
+      setHostedUrl(buildHostedUrl(info.feedId));
     }
   }, [currentFeedGuid]);
-
-  // Restore feed credentials from saved token
-  const handleRestore = async () => {
-    if (!restoreFeedId.trim() || !restoreToken.trim()) {
-      setMessage({ type: 'error', text: 'Please enter both Feed ID and Edit Token' });
-      return;
-    }
-
-    setRestoreLoading(true);
-    setMessage(null);
-
-    try {
-      // Try to update the feed with the provided credentials to verify they work
-      const xml = generateCurrentFeedXml();
-      await updateHostedFeed(restoreFeedId.trim(), restoreToken.trim(), xml, currentFeedTitle);
-
-      // Credentials work - save them
-      const newInfo: HostedFeedInfo = {
-        feedId: restoreFeedId.trim(),
-        editToken: restoreToken.trim(),
-        createdAt: Date.now(),
-        lastUpdated: Date.now()
-      };
-      saveHostedFeedInfo(currentFeedGuid, newInfo);
-      setHostedInfo(newInfo);
-      setHostedUrl(buildHostedUrl(restoreFeedId.trim()));
-      setShowRestore(false);
-      setRestoreFeedId('');
-      setRestoreToken('');
-      setMessage({ type: 'success', text: 'Feed restored and updated!' });
-    } catch (err) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Invalid credentials' });
-    } finally {
-      setRestoreLoading(false);
-    }
-  };
-
-  // Import feed content and restore credentials
-  const handleImportAndRestore = async () => {
-    if (!restoreFeedId.trim() || !restoreToken.trim()) {
-      setMessage({ type: 'error', text: 'Please enter both Feed ID and Edit Token' });
-      return;
-    }
-
-    if (!onImport) {
-      setMessage({ type: 'error', text: 'Import not available' });
-      return;
-    }
-
-    setRestoreLoading(true);
-    setMessage(null);
-
-    try {
-      // Fetch the feed XML (public, no auth needed)
-      const feedUrl = buildHostedUrl(restoreFeedId.trim());
-      const response = await fetch(feedUrl);
-      if (!response.ok) {
-        throw new Error('Feed not found');
-      }
-      const xml = await response.text();
-
-      // Verify the token works by doing a test (we'll update after import)
-      // For now just save the credentials - they'll be validated on next save
-      const newInfo: HostedFeedInfo = {
-        feedId: restoreFeedId.trim(),
-        editToken: restoreToken.trim(),
-        createdAt: Date.now(),
-        lastUpdated: Date.now()
-      };
-
-      // Import the feed content
-      onImport(xml);
-
-      // Save credentials (using the imported feed's podcastGuid will happen after import)
-      // Store with a temporary key, will be updated when user saves
-      pendingHostedStorage.save(newInfo);
-
-      setShowRestore(false);
-      setRestoreFeedId('');
-      setRestoreToken('');
-      onClose();
-      setMessage({ type: 'success', text: 'Feed imported! Save to verify your token.' });
-    } catch (err) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Failed to import feed' });
-    } finally {
-      setRestoreLoading(false);
-    }
-  };
 
   const handleSave = async () => {
     setLoading(true);
@@ -430,80 +296,42 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
           });
           break;
         }
-        case 'hosted':
-          const hostedXml = generateCurrentFeedXml();
-
-          // If there's a legacy feed with mismatched feedId, update it first
-          if (legacyHostedInfo && legacyHostedInfo.feedId !== currentFeedGuid) {
-            try {
-              await updateHostedFeed(legacyHostedInfo.feedId, legacyHostedInfo.editToken, hostedXml, currentFeedTitle);
-            } catch (legacyErr) {
-              // Log but don't fail - legacy feed update is best-effort
-              console.warn('Failed to update legacy feed:', legacyErr);
-            }
+        case 'hosted': {
+          const health = await checkSignerConnection();
+          if (!health.connected) {
+            setMessage({ type: 'error', text: health.error ?? 'Nostr signer is not connected.' });
+            setLoading(false);
+            return;
           }
 
+          const hostedXml = generateCurrentFeedXml();
+
           if (hostedInfo) {
-            // Update existing feed - use Nostr auth if linked, otherwise token
-            let updateResult;
-            if (isNostrLinked) {
-              updateResult = await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle);
-            } else {
-              updateResult = await updateHostedFeed(hostedInfo.feedId, hostedInfo.editToken, hostedXml, currentFeedTitle);
-            }
+            const updateResult = await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle);
             const updatedInfo = { ...hostedInfo, lastUpdated: Date.now() };
             saveHostedFeedInfo(currentFeedGuid, updatedInfo);
             setHostedInfo(updatedInfo);
 
-            // Show PI notification result
             if (updateResult.podcastIndexId) {
               setPodcastIndexPending(true);
               setMessage({ type: 'success', text: 'Feed updated! Podcast Index notified.' });
             } else {
               showSuccessAndClose('Feed updated!');
             }
-          } else if (pendingToken || legacyHostedInfo) {
-            // Create new feed at correct URL - use Nostr auth if user opted in
-            // Use legacy token if available, otherwise use pending token
-            const tokenToUse = legacyHostedInfo?.editToken || pendingToken;
-            if (!tokenToUse) {
-              throw new Error('No edit token available');
-            }
-
-            let hostedResult;
-            let newInfo: HostedFeedInfo;
-            const shouldLinkNostr = isLoggedIn && nostrState.user?.pubkey;
-            if (shouldLinkNostr) {
-              hostedResult = await createHostedFeedWithNostr(hostedXml, currentFeedTitle, currentFeedGuid, tokenToUse);
-              newInfo = {
-                feedId: hostedResult.feedId,
-                editToken: tokenToUse,
-                createdAt: Date.now(),
-                lastUpdated: Date.now(),
-                ownerPubkey: nostrState.user!.pubkey,
-                linkedAt: Date.now()
-              };
-            } else {
-              hostedResult = await createHostedFeed(hostedXml, currentFeedTitle, currentFeedGuid, tokenToUse);
-              newInfo = {
-                feedId: hostedResult.feedId,
-                editToken: tokenToUse,
-                createdAt: Date.now(),
-                lastUpdated: Date.now()
-              };
-            }
+          } else {
+            const hostedResult = await createHostedFeedWithNostr(hostedXml, currentFeedTitle, currentFeedGuid);
+            const newInfo: HostedFeedInfo = {
+              feedId: hostedResult.feedId,
+              createdAt: Date.now(),
+              lastUpdated: Date.now(),
+              ownerPubkey: nostrState.user!.pubkey,
+              linkedAt: Date.now()
+            };
             saveHostedFeedInfo(currentFeedGuid, newInfo);
             setHostedInfo(newInfo);
             setHostedUrl(buildHostedUrl(hostedResult.feedId));
-            setPendingToken(null);
-            setLegacyHostedInfo(null);
-            setTokenAcknowledged(false);
 
-            // Build success message with PI result
-            let successMsg = legacyHostedInfo
-              ? 'Feed migrated to new URL and legacy URL updated!'
-              : (shouldLinkNostr ? 'Feed created and linked to your Nostr identity!' : 'Feed created!');
-
+            let successMsg = 'Feed created and linked to your Nostr identity!';
             if (hostedResult.podcastIndexId) {
               setPodcastIndexPending(true);
               successMsg += ' Podcast Index notified.';
@@ -511,6 +339,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
             setMessage({ type: 'success', text: successMsg });
           }
           break;
+        }
         case 'podcastIndex': {
           const submitUrl = podcastIndexSubmitUrl.trim();
           if (!submitUrl) {
@@ -555,40 +384,6 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
 
   const handleClose = () => {
     onClose();
-  };
-
-  // Link Nostr identity to existing feed
-  const handleLinkNostr = async () => {
-    if (!hostedInfo) return;
-
-    setLinkingNostr(true);
-    setMessage(null);
-
-    const health = await checkSignerConnection();
-    if (!health.connected) {
-      setMessage({ type: 'error', text: health.error ?? 'Nostr signer is not connected.' });
-      setLinkingNostr(false);
-      return;
-    }
-
-    try {
-      const result = await linkNostrToFeed(hostedInfo.feedId, hostedInfo.editToken);
-
-      // Update local storage with linked pubkey
-      const updatedInfo = {
-        ...hostedInfo,
-        ownerPubkey: result.pubkey,
-        linkedAt: Date.now()
-      };
-      saveHostedFeedInfo(currentFeedGuid, updatedInfo);
-      setHostedInfo(updatedInfo);
-
-      setMessage({ type: 'success', text: 'Nostr identity linked! You can now sign in to edit.' });
-    } catch (err) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Failed to link Nostr identity' });
-    } finally {
-      setLinkingNostr(false);
-    }
   };
 
   return (
@@ -896,108 +691,21 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
             <div style={{ marginTop: '16px' }}>
               <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '12px' }}>
                 {hostedInfo
-                  ? 'Your feed is already hosted. Click Save to update it with your latest changes.'
-                  : legacyHostedInfo
-                    ? 'Your feed URL will be migrated to match the Podcast GUID. Both old and new URLs will be updated.'
-                    : pendingToken
-                      ? 'Save your edit token before uploading!'
-                      : 'Host your RSS feed on MSP. No account required - just save your edit token!'}
+                  ? 'Your feed is already hosted. Click Upload to update it with your latest changes.'
+                  : isLoggedIn
+                    ? 'Host your RSS feed on MSP. Managed with your Nostr identity — no token needed.'
+                    : 'Nostr login required to host a feed.'}
               </p>
-              {legacyHostedInfo && !hostedInfo && (
-                <div style={{ marginTop: '12px', padding: '12px', backgroundColor: 'rgba(59, 130, 246, 0.1)', borderRadius: '8px', border: '1px solid rgba(59, 130, 246, 0.3)' }}>
-                  <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: '8px' }}>
-                    <strong style={{ color: '#3b82f6' }}>Feed Migration</strong>
-                  </p>
-                  <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)', marginBottom: '4px' }}>
-                    Old URL: <code style={{ fontSize: '0.65rem' }}>{buildHostedUrl(legacyHostedInfo.feedId)}</code>
-                  </p>
-                  <p style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>
-                    New URL: <code style={{ fontSize: '0.65rem' }}>{buildHostedUrl(currentFeedGuid)}</code>
-                  </p>
-                </div>
-              )}
-              {pendingToken && !hostedInfo && !legacyHostedInfo && (
-                <div style={{ marginTop: '16px', padding: '12px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '8px', border: '1px solid var(--warning, #f59e0b)' }}>
-                  <label style={{ display: 'block', marginBottom: '4px', fontSize: '0.875rem', fontWeight: 600, color: 'var(--warning, #f59e0b)' }}>
-                    {isLoggedIn ? 'Backup Token (save this!)' : 'Edit Token (save this!)'}
-                  </label>
-                  <input
-                    type="text"
-                    value={pendingToken}
-                    readOnly
-                    onClick={(e) => (e.target as HTMLInputElement).select()}
-                    style={{
-                      width: '100%',
-                      padding: '8px 12px',
-                      borderRadius: '4px',
-                      border: '1px solid var(--warning, #f59e0b)',
-                      backgroundColor: 'var(--bg-secondary)',
-                      color: 'var(--text-primary)',
-                      fontSize: '0.75rem',
-                      fontFamily: 'monospace'
-                    }}
-                  />
-                  <p style={{ color: 'var(--warning, #f59e0b)', fontSize: '0.75rem', marginTop: '8px', marginBottom: '12px' }}>
-                    You need this token to edit your feed later. Save it somewhere safe!
-                  </p>
-                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
-                    <button
-                      className="btn btn-secondary"
-                      onClick={() => {
-                        navigator.clipboard.writeText(pendingToken);
-                        setMessage({ type: 'success', text: 'Token copied to clipboard' });
-                      }}
-                    >
-                      Copy Token
-                    </button>
-                    <button
-                      className="btn btn-secondary"
-                      onClick={() => {
-                        downloadHostedFeedBackup(currentFeedGuid, pendingToken, currentFeedTitle, currentFeedGuid);
-                        setMessage({ type: 'success', text: 'Backup file downloaded' });
-                      }}
-                    >
-                      Download Backup
-                    </button>
-                  </div>
-                  <label style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                    cursor: 'pointer',
-                    fontSize: '0.75rem',
-                    color: 'var(--text-primary)',
-                    padding: '8px',
-                    backgroundColor: tokenAcknowledged ? 'rgba(16, 185, 129, 0.1)' : 'transparent',
-                    borderRadius: '4px',
-                    border: tokenAcknowledged ? '1px solid var(--success, #10b981)' : '1px solid var(--border-color)'
-                  }}>
-                    <input
-                      type="checkbox"
-                      checked={tokenAcknowledged}
-                      onChange={(e) => setTokenAcknowledged(e.target.checked)}
-                      style={{ width: '16px', height: '16px' }}
-                    />
-                    <span>I have saved my edit token</span>
-                  </label>
-                  <button
-                    className="btn btn-secondary"
-                    style={{ fontSize: '0.75rem', padding: '6px 12px', marginTop: '12px', width: '100%' }}
-                    onClick={() => {
-                      setPendingToken(null);
-                      setTokenAcknowledged(false);
-                      setShowRestore(true);
-                    }}
-                  >
-                    Already have a token? Restore existing feed
-                  </button>
-                </div>
+              {!isLoggedIn && (
+                <p style={{ color: 'var(--warning, #f59e0b)', fontSize: '0.75rem', padding: '8px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '4px' }}>
+                  Sign in with Nostr to host and manage your feed from any device.
+                </p>
               )}
               {hostedUrl && (
                 <div style={{ marginTop: '16px', padding: '12px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '8px', border: '1px solid var(--success)' }}>
                   <label style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px', fontSize: '0.875rem', fontWeight: 600, color: 'var(--success)' }}>
                     Your Feed URL
-                    {isNostrLinked && (
+                    {isNostrOwner && (
                       <span style={{ fontSize: '0.7rem', padding: '2px 6px', backgroundColor: 'rgba(139, 92, 246, 0.2)', color: '#a78bfa', borderRadius: '4px' }}>
                         Linked to Nostr
                       </span>
@@ -1061,176 +769,6 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                         >
                           Check status or add manually →
                         </a>
-                      </p>
-                    </div>
-                  )}
-                  {/* Link Nostr button for existing feeds without Nostr link */}
-                  {isLoggedIn && hostedInfo && !isNostrLinked && (
-                    <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid var(--border-color)' }}>
-                      <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: '8px' }}>
-                        Link your Nostr identity to manage this feed without needing the token.
-                      </p>
-                      <button
-                        className="btn btn-secondary"
-                        style={{ fontSize: '0.75rem' }}
-                        onClick={handleLinkNostr}
-                        disabled={linkingNostr}
-                      >
-                        {linkingNostr ? 'Linking...' : 'Link Nostr Identity'}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
-              {!hostedInfo && !pendingToken && !legacyHostedInfo && (
-                <div style={{ marginTop: '12px' }}>
-                  <p style={{ color: 'var(--warning, #f59e0b)', fontSize: '0.75rem', padding: '8px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '4px', marginBottom: '12px' }}>
-                    Your edit token will be saved in this browser. If you clear browser data, you won't be able to update this feed.
-                  </p>
-                  {!showRestore ? (
-                    <button
-                      className="btn btn-secondary"
-                      style={{ fontSize: '0.75rem', padding: '6px 12px' }}
-                      onClick={() => setShowRestore(true)}
-                    >
-                      Have a token? Restore existing feed
-                    </button>
-                  ) : (
-                    <div style={{ padding: '12px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '8px', border: '1px solid var(--border)' }}>
-                      {/* Upload backup file - primary option */}
-                      <label
-                        style={{
-                          display: 'flex',
-                          flexDirection: 'column',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          padding: '20px',
-                          marginBottom: '12px',
-                          border: '2px dashed var(--border-color)',
-                          borderRadius: '8px',
-                          backgroundColor: 'var(--bg-secondary)',
-                          cursor: 'pointer',
-                          transition: 'border-color 0.2s'
-                        }}
-                      >
-                        <span style={{ fontSize: '1.5rem', marginBottom: '8px' }}>📁</span>
-                        <span style={{ fontSize: '0.875rem', fontWeight: 600, color: 'var(--text-primary)' }}>
-                          Upload Backup File
-                        </span>
-                        <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '4px' }}>
-                          Drop your .json backup file here or click to browse
-                        </span>
-                        <input
-                          type="file"
-                          accept=".json"
-                          onChange={(e) => {
-                            const file = e.target.files?.[0];
-                            if (!file) return;
-                            const reader = new FileReader();
-                            reader.onload = (event) => {
-                              try {
-                                const json = JSON.parse(event.target?.result as string);
-                                // Support both old and new format
-                                const feedId = json.feedId || json.feed_id || json.msp_hosted_feed_backup?.feed_id;
-                                const token = json.editToken || json.edit_token || json.msp_hosted_feed_backup?.edit_token;
-                                if (feedId && token) {
-                                  setRestoreFeedId(feedId);
-                                  setRestoreToken(token);
-                                  setMessage({ type: 'success', text: 'Backup file loaded! Click "Link Credentials" to restore.' });
-                                } else {
-                                  setMessage({ type: 'error', text: 'Invalid backup file format' });
-                                }
-                              } catch {
-                                setMessage({ type: 'error', text: 'Could not parse backup file' });
-                              }
-                            };
-                            reader.readAsText(file);
-                            e.target.value = '';
-                          }}
-                          style={{ display: 'none' }}
-                        />
-                      </label>
-
-                      {/* Divider */}
-                      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', margin: '12px 0' }}>
-                        <div style={{ flex: 1, height: '1px', backgroundColor: 'var(--border-color)' }} />
-                        <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>OR ENTER MANUALLY</span>
-                        <div style={{ flex: 1, height: '1px', backgroundColor: 'var(--border-color)' }} />
-                      </div>
-
-                      {/* Manual entry fields */}
-                      <label style={{ display: 'block', marginBottom: '4px', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                        Feed ID
-                      </label>
-                      <input
-                        type="text"
-                        value={restoreFeedId}
-                        onChange={(e) => setRestoreFeedId(e.target.value)}
-                        placeholder="e.g. 95761582-a064-4430-8192-4571d8d3715b"
-                        style={{
-                          width: '100%',
-                          padding: '8px 12px',
-                          borderRadius: '4px',
-                          border: '1px solid var(--border)',
-                          backgroundColor: 'var(--bg-secondary)',
-                          color: 'var(--text-primary)',
-                          fontSize: '0.75rem',
-                          fontFamily: 'monospace',
-                          marginBottom: '8px'
-                        }}
-                      />
-                      <label style={{ display: 'block', marginBottom: '4px', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                        Edit Token
-                      </label>
-                      <input
-                        type="text"
-                        value={restoreToken}
-                        onChange={(e) => setRestoreToken(e.target.value)}
-                        placeholder="Your saved edit token"
-                        style={{
-                          width: '100%',
-                          padding: '8px 12px',
-                          borderRadius: '4px',
-                          border: '1px solid var(--border)',
-                          backgroundColor: 'var(--bg-secondary)',
-                          color: 'var(--text-primary)',
-                          fontSize: '0.75rem',
-                          fontFamily: 'monospace',
-                          marginBottom: '12px'
-                        }}
-                      />
-                      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                        <button
-                          className="btn btn-primary"
-                          style={{ fontSize: '0.75rem', padding: '6px 12px' }}
-                          onClick={handleRestore}
-                          disabled={restoreLoading}
-                        >
-                          {restoreLoading ? 'Loading...' : 'Link Credentials'}
-                        </button>
-                        <button
-                          className="btn btn-secondary"
-                          style={{ fontSize: '0.75rem', padding: '6px 12px' }}
-                          onClick={handleImportAndRestore}
-                          disabled={restoreLoading}
-                        >
-                          Import & Link
-                        </button>
-                        <button
-                          className="btn btn-secondary"
-                          style={{ fontSize: '0.75rem', padding: '6px 12px' }}
-                          onClick={() => {
-                            setShowRestore(false);
-                            setRestoreFeedId('');
-                            setRestoreToken('');
-                          }}
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                      <p style={{ color: 'var(--text-secondary)', fontSize: '0.7rem', marginTop: '8px' }}>
-                        <strong>Link Credentials</strong>: Links credentials without changing current content<br />
-                        <strong>Import & Link</strong>: Fetches feed content and loads it into the editor
                       </p>
                     </div>
                   )}
@@ -1335,7 +873,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                 <li><strong>Local Storage</strong> - Save to your browser's local storage. Data persists until you clear browser data.</li>
                 <li><strong>Download XML</strong> - Download the RSS feed as an XML file to your computer.</li>
                 <li><strong>Copy to Clipboard</strong> - Copy the RSS XML to your clipboard for pasting elsewhere.</li>
-                <li><strong>Host on MSP</strong> - Host your feed on MSP servers. Get a permanent URL for your RSS feed to use in any app.{isLoggedIn && ' You can link your Nostr identity to edit from any device without needing the token.'}</li>
+                <li><strong>Host on MSP</strong> - Host your feed on MSP servers. Get a permanent URL for your RSS feed to use in any app. Managed with your Nostr identity — edit from any device.</li>
                 <li><strong>Submit to PodcastIndex</strong> - Submit a feed URL to Podcast Index so it gets indexed and becomes discoverable in apps like Fountain, Castamatic, and others.</li>
                 <li><strong>Publish to Nostr Music</strong> - Publishes each track (kind 36787) and the playlist (kind 34139) as Nostr events for Nostr-native music clients like Wavlake and Fountain. Audio files must already be hosted somewhere - these events just point to them. Not a podcast RSS feed.</li>
                 {showExperimental && <li><strong>Save RSS feed to Nostr 🧪</strong> - Stores the entire RSS XML inside a Nostr event (kind 30054) on your relays. Personal cross-device backup tied to your Nostr key. Not readable by podcast apps.</li>}

--- a/src/utils/artistPublish.ts
+++ b/src/utils/artistPublish.ts
@@ -1,0 +1,129 @@
+import type { Album, PublisherFeed } from '../types/feed';
+import { generateRssFeed, generatePublisherRssFeed } from './xmlGenerator';
+import {
+  createHostedFeedWithNostr,
+  updateHostedFeedWithNostr,
+  getHostedFeedInfo,
+  saveHostedFeedInfo,
+  buildHostedUrl,
+} from './hostedFeed';
+
+export interface HostedFeedResult {
+  feedId: string;
+  url: string;
+  podcastIndexId?: number;
+}
+
+export type PublishStepId = 'album-host' | 'publisher-host';
+export type PublishStepStatus = 'pending' | 'in-progress' | 'done' | 'failed';
+
+export interface PublishStep {
+  id: PublishStepId;
+  status: PublishStepStatus;
+  message?: string;
+}
+
+export interface HostBothResult {
+  album: HostedFeedResult;
+  publisher: HostedFeedResult;
+  patchedAlbum: Album;
+  patchedPublisherFeed: PublisherFeed;
+}
+
+const hostOne = async (
+  xml: string,
+  title: string,
+  podcastGuid: string,
+  ownerPubkey: string
+): Promise<HostedFeedResult> => {
+  const existing = getHostedFeedInfo(podcastGuid);
+  if (existing) {
+    const updateResult = await updateHostedFeedWithNostr(existing.feedId, xml, title);
+    saveHostedFeedInfo(podcastGuid, { ...existing, lastUpdated: Date.now() });
+    return {
+      feedId: existing.feedId,
+      url: buildHostedUrl(existing.feedId),
+      podcastIndexId: updateResult.podcastIndexId,
+    };
+  }
+  const createResult = await createHostedFeedWithNostr(xml, title, podcastGuid);
+  saveHostedFeedInfo(podcastGuid, {
+    feedId: createResult.feedId,
+    editToken: '',
+    createdAt: Date.now(),
+    lastUpdated: Date.now(),
+    ownerPubkey,
+    linkedAt: Date.now(),
+  });
+  return {
+    feedId: createResult.feedId,
+    url: buildHostedUrl(createResult.feedId),
+    podcastIndexId: createResult.podcastIndexId,
+  };
+};
+
+export async function hostBothOnMSP(
+  album: Album,
+  publisherFeed: PublisherFeed,
+  userPubkey: string,
+  onStep?: (step: PublishStep) => void
+): Promise<HostBothResult> {
+  const now = new Date().toUTCString();
+
+  // Precompute hosted URLs so we can inject cross-links before upload.
+  const computedAlbumUrl = buildHostedUrl(album.podcastGuid);
+  const computedPublisherUrl = buildHostedUrl(publisherFeed.podcastGuid);
+
+  const patchedAlbum: Album = {
+    ...album,
+    lastBuildDate: now,
+    publisher: album.publisher
+      ? { ...album.publisher, feedUrl: album.publisher.feedUrl || computedPublisherUrl }
+      : { feedGuid: publisherFeed.podcastGuid, feedUrl: computedPublisherUrl },
+  };
+
+  const patchedPublisherFeed: PublisherFeed = {
+    ...publisherFeed,
+    lastBuildDate: now,
+    remoteItems: publisherFeed.remoteItems.map((item) =>
+      item.feedGuid === album.podcastGuid && !item.feedUrl
+        ? { ...item, feedUrl: computedAlbumUrl }
+        : item
+    ),
+  };
+
+  const albumXml = generateRssFeed(patchedAlbum);
+  const pubXml = generatePublisherRssFeed(patchedPublisherFeed);
+
+  onStep?.({ id: 'album-host', status: 'in-progress' });
+  let albumResult: HostedFeedResult;
+  try {
+    albumResult = await hostOne(albumXml, patchedAlbum.title || 'Album', album.podcastGuid, userPubkey);
+    onStep?.({ id: 'album-host', status: 'done' });
+  } catch (err) {
+    onStep?.({ id: 'album-host', status: 'failed', message: err instanceof Error ? err.message : 'Failed to host album' });
+    throw err;
+  }
+
+  onStep?.({ id: 'publisher-host', status: 'in-progress' });
+  let publisherResult: HostedFeedResult;
+  try {
+    publisherResult = await hostOne(
+      pubXml,
+      patchedPublisherFeed.title || 'Publisher Catalog',
+      publisherFeed.podcastGuid,
+      userPubkey
+    );
+    onStep?.({ id: 'publisher-host', status: 'done' });
+  } catch (err) {
+    onStep?.({ id: 'publisher-host', status: 'failed', message: err instanceof Error ? err.message : 'Failed to host publisher' });
+    throw err;
+  }
+
+  return {
+    album: albumResult,
+    publisher: publisherResult,
+    patchedAlbum,
+    patchedPublisherFeed,
+  };
+}

--- a/src/utils/blossom.ts
+++ b/src/utils/blossom.ts
@@ -14,6 +14,33 @@ const FILE_METADATA_KIND = 1063;
 
 const CLIENT_TAG = 'MSP 2.0';
 
+// Well-known public Blossom servers tried in parallel on media upload
+export const BLOSSOM_MEDIA_SERVERS = [
+  'https://blossom.primal.net',
+  'https://nostr.download',
+];
+
+export interface MediaUploadResult {
+  success: boolean;
+  message: string;
+  url?: string;
+  serversSucceeded: number;
+  serversTotal: number;
+}
+
+/**
+ * Returns true if the URL points at one of the known Blossom media servers.
+ * Used to suppress the "unrecognized audio extension" warning for hash-based
+ * Blossom URLs that have no file extension.
+ */
+export function isBlossomMediaUrl(url: string): boolean {
+  const normalized = url.replace(/\/$/, '');
+  return BLOSSOM_MEDIA_SERVERS.some(server => {
+    const base = server.replace(/\/$/, '');
+    return normalized.startsWith(base);
+  });
+}
+
 /**
  * Calculate SHA256 hash of content
  */
@@ -26,14 +53,126 @@ async function sha256Hash(content: string): Promise<string> {
 }
 
 /**
+ * Calculate SHA256 hash of binary data
+ */
+async function sha256HashBinary(data: ArrayBuffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Upload a media file to all known Blossom servers in parallel.
+ * Returns the URL from the first server that accepts the upload, plus how many
+ * servers succeeded so callers can surface partial failures.
+ */
+export async function uploadMediaToBlossom(
+  file: File,
+  opts?: { signal?: AbortSignal; timeoutMs?: number }
+): Promise<MediaUploadResult> {
+  const serversTotal = BLOSSOM_MEDIA_SERVERS.length;
+
+  if (!hasSigner()) {
+    return {
+      success: false,
+      message: 'Nostr login required for Blossom upload',
+      serversSucceeded: 0,
+      serversTotal,
+    };
+  }
+
+  try {
+    const pubkey = await getPublicKeyWithTimeout();
+    const arrayBuffer = await file.arrayBuffer();
+    const hash = await sha256HashBinary(arrayBuffer);
+
+    const timeoutMs = opts?.timeoutMs ?? 180000;
+    const authEvent = await createBlossomAuthEvent(
+      hash,
+      pubkey,
+      'upload',
+      Math.max(600, Math.ceil(timeoutMs / 1000) + 60)
+    );
+    const signedAuthEvent = await signEventWithTimeout(authEvent);
+    const authHeader = 'Nostr ' + btoa(JSON.stringify(signedAuthEvent));
+
+    const uploadToServer = async (server: string): Promise<string> => {
+      const serverUrl = server.replace(/\/$/, '');
+      const controller = new AbortController();
+      const t = setTimeout(() => controller.abort(), timeoutMs);
+      const onExternalAbort = () => controller.abort();
+      opts?.signal?.addEventListener('abort', onExternalAbort);
+      try {
+        const response = await fetch(`${serverUrl}/upload`, {
+          method: 'PUT',
+          headers: {
+            'Authorization': authHeader,
+            'Content-Type': file.type || 'application/octet-stream',
+          },
+          body: arrayBuffer,
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`${serverUrl}: ${response.status}`);
+        }
+        const result = await response.json();
+        return result.url || `${serverUrl}/${hash}`;
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw new Error(`${serverUrl}: timed out`);
+        }
+        throw err;
+      } finally {
+        clearTimeout(t);
+        opts?.signal?.removeEventListener('abort', onExternalAbort);
+      }
+    };
+
+    const results = await Promise.allSettled(
+      BLOSSOM_MEDIA_SERVERS.map(server => uploadToServer(server))
+    );
+
+    const serversSucceeded = results.filter(r => r.status === 'fulfilled').length;
+    const firstSuccess = results.find(r => r.status === 'fulfilled');
+    if (firstSuccess && firstSuccess.status === 'fulfilled') {
+      if (serversSucceeded < serversTotal) {
+        console.warn(`Blossom: uploaded to ${serversSucceeded}/${serversTotal} servers`);
+      }
+      return {
+        success: true,
+        message: 'Uploaded successfully',
+        url: firstSuccess.value,
+        serversSucceeded,
+        serversTotal,
+      };
+    }
+
+    const errors = results
+      .filter(r => r.status === 'rejected')
+      .map(r => (r as PromiseRejectedResult).reason?.message || 'Unknown error')
+      .join('; ');
+    return {
+      success: false,
+      message: `All servers rejected the upload: ${errors}`,
+      serversSucceeded: 0,
+      serversTotal,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, message, serversSucceeded: 0, serversTotal };
+  }
+}
+
+/**
  * Create Blossom auth event (kind 24242)
  */
 async function createBlossomAuthEvent(
   hash: string,
   pubkey: string,
-  action: 'upload' | 'delete' = 'upload'
+  action: 'upload' | 'delete' = 'upload',
+  expirationSeconds?: number
 ): Promise<NostrEvent> {
-  const expiration = Math.floor(Date.now() / 1000) + 300; // 5 minutes from now
+  const expiration = Math.floor(Date.now() / 1000) + (expirationSeconds ?? 300);
 
   return {
     kind: BLOSSOM_AUTH_KIND,

--- a/src/utils/hostedFeed.ts
+++ b/src/utils/hostedFeed.ts
@@ -29,93 +29,14 @@ export function clearHostedFeedInfo(podcastGuid: string): void {
 
 interface CreateFeedResponse {
   feedId: string;
-  editToken: string;
   url: string;
   blobUrl: string;
   podcastIndexId?: number;
 }
 
-/**
- * Generate a random edit token (32 bytes, base64url encoded)
- */
-export function generateEditToken(): string {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  // Convert to base64url
-  const base64 = btoa(String.fromCharCode(...bytes));
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
-
-/**
- * Create a new hosted feed
- */
-export async function createHostedFeed(
-  xml: string,
-  title: string,
-  podcastGuid: string,
-  editToken?: string
-): Promise<CreateFeedResponse> {
-  const response = await fetch('/api/hosted', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ xml, title, podcastGuid, editToken })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to create feed' }));
-    throw new Error(error.error || 'Failed to create feed');
-  }
-
-  return response.json();
-}
-
 interface UpdateFeedResponse {
   success: boolean;
   podcastIndexId?: number;
-}
-
-/**
- * Update an existing hosted feed
- */
-export async function updateHostedFeed(
-  feedId: string,
-  editToken: string,
-  xml: string,
-  title: string
-): Promise<UpdateFeedResponse> {
-  const response = await fetch(`/api/hosted/${feedId}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Edit-Token': editToken
-    },
-    body: JSON.stringify({ xml, title })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to update feed' }));
-    throw new Error(error.error || 'Failed to update feed');
-  }
-
-  return response.json();
-}
-
-/**
- * Delete a hosted feed
- */
-export async function deleteHostedFeed(
-  feedId: string,
-  editToken: string
-): Promise<void> {
-  const response = await fetch(`/api/hosted/${feedId}`, {
-    method: 'DELETE',
-    headers: { 'X-Edit-Token': editToken }
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to delete feed' }));
-    throw new Error(error.error || 'Failed to delete feed');
-  }
 }
 
 /**
@@ -130,85 +51,28 @@ export function buildHostedUrl(feedId: string): string {
 }
 
 /**
- * Backup file structure for hosted feeds
- */
-export interface HostedFeedBackup {
-  _info: string;
-  album: string;
-  feedUrl: string;
-  feedId: string;
-  podcastGuid: string;
-  editToken: string;
-  createdAt: string;
-}
-
-/**
- * Download a backup JSON file containing hosted feed credentials
- */
-export function downloadHostedFeedBackup(
-  feedId: string,
-  editToken: string,
-  albumTitle: string,
-  podcastGuid?: string
-): void {
-  const backup: HostedFeedBackup = {
-    _info: 'MSP Hosted Feed Backup - Keep this file safe!',
-    album: albumTitle,
-    feedUrl: buildHostedUrl(feedId),
-    feedId: feedId,
-    podcastGuid: podcastGuid || feedId,
-    editToken: editToken,
-    createdAt: new Date().toISOString()
-  };
-
-  const json = JSON.stringify(backup, null, 2);
-  const blob = new Blob([json], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-
-  // Generate filename: sanitize album title
-  const titleSlug = albumTitle
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, 30) || 'untitled';
-  const feedIdPrefix = feedId.slice(0, 8);
-  const filename = `msp-feed-backup-${titleSlug}-${feedIdPrefix}.json`;
-
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-}
-
-// ============================================
-// Nostr-authenticated API functions
-// ============================================
-
-/**
- * Create a hosted feed with Nostr authentication (for logged-in users)
- * The feed will be linked to the user's Nostr identity
+ * Create a hosted feed with Nostr authentication (required)
+ * The feed is linked to the user's Nostr identity from creation.
  */
 export async function createHostedFeedWithNostr(
   xml: string,
   title: string,
-  podcastGuid: string,
-  editToken?: string
+  podcastGuid: string
 ): Promise<CreateFeedResponse> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-
-  // Add Nostr auth if available
-  if (hasSigner()) {
-    const url = `${window.location.origin}/api/hosted`;
-    headers['Authorization'] = await createAdminAuthHeader(url, 'POST');
+  if (!hasSigner()) {
+    throw new Error('Nostr login required to host a feed');
   }
+
+  const url = `${window.location.origin}/api/hosted`;
+  const authHeader = await createAdminAuthHeader(url, 'POST');
 
   const response = await fetch('/api/hosted', {
     method: 'POST',
-    headers,
-    body: JSON.stringify({ xml, title, podcastGuid, editToken })
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': authHeader
+    },
+    body: JSON.stringify({ xml, title, podcastGuid })
   });
 
   if (!response.ok) {
@@ -228,7 +92,7 @@ export async function updateHostedFeedWithNostr(
   title: string
 ): Promise<UpdateFeedResponse> {
   if (!hasSigner()) {
-    throw new Error('Not logged in with Nostr');
+    throw new Error('Nostr login required to update a feed');
   }
 
   const url = `${window.location.origin}/api/hosted/${feedId}`;
@@ -251,39 +115,24 @@ export async function updateHostedFeedWithNostr(
   return response.json();
 }
 
-interface LinkNostrResponse {
-  success: boolean;
-  message: string;
-  pubkey: string;
-}
-
 /**
- * Link a Nostr identity to an existing feed
- * Requires both the edit token (proves ownership) and Nostr auth (identity to link)
+ * Delete a hosted feed with Nostr authentication
  */
-export async function linkNostrToFeed(
-  feedId: string,
-  editToken: string
-): Promise<LinkNostrResponse> {
+export async function deleteHostedFeedWithNostr(feedId: string): Promise<void> {
   if (!hasSigner()) {
-    throw new Error('Not logged in with Nostr');
+    throw new Error('Nostr login required to delete a feed');
   }
 
   const url = `${window.location.origin}/api/hosted/${feedId}`;
-  const authHeader = await createAdminAuthHeader(url, 'PATCH');
+  const authHeader = await createAdminAuthHeader(url, 'DELETE');
 
   const response = await fetch(`/api/hosted/${feedId}`, {
-    method: 'PATCH',
-    headers: {
-      'X-Edit-Token': editToken,
-      'Authorization': authHeader
-    }
+    method: 'DELETE',
+    headers: { 'Authorization': authHeader }
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to link Nostr identity' }));
-    throw new Error(error.error || 'Failed to link Nostr identity');
+    const error = await response.json().catch(() => ({ error: 'Failed to delete feed' }));
+    throw new Error(error.error || 'Failed to delete feed');
   }
-
-  return response.json();
 }

--- a/src/utils/publisherPublish.ts
+++ b/src/utils/publisherPublish.ts
@@ -6,15 +6,12 @@ import { generatePublisherRssFeed } from './xmlGenerator';
 import {
   getHostedFeedInfo,
   saveHostedFeedInfo,
-  createHostedFeed,
   createHostedFeedWithNostr,
-  updateHostedFeed,
   updateHostedFeedWithNostr,
   buildHostedUrl,
-  generateEditToken,
   type HostedFeedInfo
 } from './hostedFeed';
-import { hasSigner } from './nostrSigner';
+
 import { fetchFeedFromUrl, parseRssFeed } from './xmlParser';
 import { generateRssFeed } from './xmlGenerator';
 
@@ -132,7 +129,6 @@ function needsHosting(item: RemoteItem): boolean {
 // Host a single catalog feed on MSP
 async function hostCatalogFeed(
   item: RemoteItem,
-  linkNostr: boolean,
   nostrPubkey?: string
 ): Promise<FeedUpdateResult> {
   const title = item.title || item.feedGuid;
@@ -179,32 +175,17 @@ async function hostCatalogFeed(
     const feedTitle = album.title || title;
 
     // Host on MSP
-    const editToken = generateEditToken();
-    const shouldLinkNostr = linkNostr && nostrPubkey && hasSigner();
-
-    let result;
     let hostedInfo: HostedFeedInfo;
 
     try {
-      if (shouldLinkNostr) {
-        result = await createHostedFeedWithNostr(cleanXml, feedTitle, item.feedGuid, editToken);
-        hostedInfo = {
-          feedId: result.feedId,
-          editToken,
-          createdAt: Date.now(),
-          lastUpdated: Date.now(),
-          ownerPubkey: nostrPubkey,
-          linkedAt: Date.now()
-        };
-      } else {
-        result = await createHostedFeed(cleanXml, feedTitle, item.feedGuid, editToken);
-        hostedInfo = {
-          feedId: result.feedId,
-          editToken,
-          createdAt: Date.now(),
-          lastUpdated: Date.now()
-        };
-      }
+      const result = await createHostedFeedWithNostr(cleanXml, feedTitle, item.feedGuid);
+      hostedInfo = {
+        feedId: result.feedId,
+        createdAt: Date.now(),
+        lastUpdated: Date.now(),
+        ownerPubkey: nostrPubkey,
+        linkedAt: Date.now()
+      };
 
       // Save credentials
       saveHostedFeedInfo(item.feedGuid, hostedInfo);
@@ -309,23 +290,8 @@ async function processCatalogFeed(
       const feedId = extractFeedIdFromUrl(feedUrl);
       if (feedId) {
         const hostedInfo = getHostedFeedInfo(album.podcastGuid);
-        if (hostedInfo && hostedInfo.feedId === feedId) {
-          // Check if we can use Nostr auth
-          const isNostrLinked = hostedInfo.ownerPubkey && hasSigner();
-
-          if (isNostrLinked) {
-            await updateHostedFeedWithNostr(feedId, updatedXml, feedTitle);
-          } else if (hostedInfo.editToken) {
-            await updateHostedFeed(feedId, hostedInfo.editToken, updatedXml, feedTitle);
-          } else {
-            // No valid auth method
-            return {
-              title: feedTitle,
-              feedGuid: item.feedGuid,
-              status: 'skipped',
-              message: 'No credentials'
-            };
-          }
+        if (hostedInfo && hostedInfo.feedId === feedId && hostedInfo.ownerPubkey) {
+          await updateHostedFeedWithNostr(feedId, updatedXml, feedTitle);
 
           // Notify PI in background (don't wait)
           notifyPodcastIndex(feedUrl, album.medium).catch(err => console.warn('PI notification failed:', err));
@@ -394,7 +360,7 @@ export async function publishPublisherFeed(
   publisherFeed: PublisherFeed,
   options: PublishOptions
 ): Promise<PublishResult> {
-  const { hostCatalogFeeds, updateCatalogFeeds, linkNostr, nostrPubkey, onProgress } = options;
+  const { hostCatalogFeeds, updateCatalogFeeds, nostrPubkey, onProgress } = options;
 
   const podcastGuid = publisherFeed.podcastGuid;
   if (!podcastGuid) {
@@ -453,7 +419,7 @@ export async function publishPublisherFeed(
           }
         });
 
-        const result = await hostCatalogFeed(item, linkNostr, nostrPubkey);
+        const result = await hostCatalogFeed(item, nostrPubkey);
         catalogHostResults.push(result);
 
         // Update the URL in our copy if hosting succeeded
@@ -482,75 +448,42 @@ export async function publishPublisherFeed(
 
     if (existingInfo) {
       // Update existing feed
-      const isNostrLinked = existingInfo.ownerPubkey && nostrPubkey === existingInfo.ownerPubkey;
-
-      if (isNostrLinked && hasSigner()) {
-        await updateHostedFeedWithNostr(existingInfo.feedId, xml, title);
-      } else {
-        await updateHostedFeed(existingInfo.feedId, existingInfo.editToken, xml, title);
-      }
-
+      await updateHostedFeedWithNostr(existingInfo.feedId, xml, title);
       hostedInfo = { ...existingInfo, lastUpdated: Date.now() };
       saveHostedFeedInfo(podcastGuid, hostedInfo);
       feedUrl = buildHostedUrl(existingInfo.feedId);
     } else {
       // Create new feed
-      const editToken = generateEditToken();
-      const shouldLinkNostr = linkNostr && nostrPubkey && hasSigner();
-
       try {
-        let result;
-        if (shouldLinkNostr) {
-          result = await createHostedFeedWithNostr(xml, title, podcastGuid, editToken);
-          hostedInfo = {
-            feedId: result.feedId,
-            editToken,
-            createdAt: Date.now(),
-            lastUpdated: Date.now(),
-            ownerPubkey: nostrPubkey,
-            linkedAt: Date.now()
-          };
-        } else {
-          result = await createHostedFeed(xml, title, podcastGuid, editToken);
-          hostedInfo = {
-            feedId: result.feedId,
-            editToken,
-            createdAt: Date.now(),
-            lastUpdated: Date.now()
-          };
-        }
-
+        const result = await createHostedFeedWithNostr(xml, title, podcastGuid);
+        hostedInfo = {
+          feedId: result.feedId,
+          createdAt: Date.now(),
+          lastUpdated: Date.now(),
+          ownerPubkey: nostrPubkey,
+          linkedAt: Date.now()
+        };
         saveHostedFeedInfo(podcastGuid, hostedInfo);
         feedUrl = result.url;
       } catch (createErr) {
         const errMsg = createErr instanceof Error ? createErr.message : '';
 
-        // Handle 409 Conflict - feed already exists
+        // Handle 409 Conflict - feed already exists, try to update via Nostr auth
         if (errMsg.includes('already exists') || errMsg.includes('409')) {
-          // If user is logged in with Nostr, try to update via Nostr auth
-          if (nostrPubkey && hasSigner()) {
-            try {
-              await updateHostedFeedWithNostr(podcastGuid, xml, title);
-              // Success - create local hostedInfo without edit token
-              hostedInfo = {
-                feedId: podcastGuid,
-                editToken: '', // We don't have the token, but Nostr works
-                createdAt: Date.now(),
-                lastUpdated: Date.now(),
-                ownerPubkey: nostrPubkey,
-                linkedAt: Date.now()
-              };
-              saveHostedFeedInfo(podcastGuid, hostedInfo);
-              feedUrl = buildHostedUrl(podcastGuid);
-            } catch (nostrErr) {
-              // Nostr update also failed - feed exists but user doesn't have access
-              throw new Error(
-                'This feed already exists on MSP. If you are the owner, use the Restore option in the Save dialog to recover your credentials, or log in with the Nostr identity linked to this feed.'
-              );
-            }
-          } else {
+          try {
+            await updateHostedFeedWithNostr(podcastGuid, xml, title);
+            hostedInfo = {
+              feedId: podcastGuid,
+              createdAt: Date.now(),
+              lastUpdated: Date.now(),
+              ownerPubkey: nostrPubkey,
+              linkedAt: Date.now()
+            };
+            saveHostedFeedInfo(podcastGuid, hostedInfo);
+            feedUrl = buildHostedUrl(podcastGuid);
+          } catch {
             throw new Error(
-              'This feed already exists on MSP. Use the Restore option in the Save dialog to recover your edit credentials.'
+              'This feed already exists on MSP. Sign in with the Nostr identity linked to this feed to update it.'
             );
           }
         } else {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -152,11 +152,11 @@ export const nostrUserStorage = {
 // Hosted feed info type (re-exported from hostedFeed)
 export interface HostedFeedInfo {
   feedId: string;
-  editToken: string;
+  editToken?: string;  // Legacy — no longer used for new feeds (Nostr auth only)
   createdAt: number;
   lastUpdated: number;
-  ownerPubkey?: string;  // Nostr pubkey if linked
-  linkedAt?: number;     // When Nostr was linked
+  ownerPubkey?: string;
+  linkedAt?: number;
 }
 
 // Hosted feed storage operations

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -10,7 +10,8 @@ export const STORAGE_KEYS = {
   FEED_TYPE: 'msp2-feed-type',
   NOSTR_USER: 'msp2-nostr-user',
   HOSTED_PREFIX: 'msp2-hosted-',
-  PENDING_HOSTED: 'msp2-pending-hosted'
+  PENDING_HOSTED: 'msp2-pending-hosted',
+  WIZARD_COMPLETE: 'msp2-wizard-complete',
 } as const;
 
 // Migration helper: convert old person format to new format
@@ -175,4 +176,10 @@ export const pendingHostedStorage = {
   load: (): HostedFeedInfo | null => getItem<HostedFeedInfo>(STORAGE_KEYS.PENDING_HOSTED),
   save: (info: HostedFeedInfo): boolean => setItem(STORAGE_KEYS.PENDING_HOSTED, info),
   clear: (): boolean => removeItem(STORAGE_KEYS.PENDING_HOSTED)
+};
+
+// New artist onboarding wizard completion flag
+export const wizardStorage = {
+  isComplete: (): boolean => getItem<boolean>(STORAGE_KEYS.WIZARD_COMPLETE) === true,
+  markComplete: (): boolean => setItem(STORAGE_KEYS.WIZARD_COMPLETE, true)
 };


### PR DESCRIPTION
4-step wizard guides new artists from zero to a live hosted feed:
1. Nostr login (inline extension + bunker URI, auto-advances on success)
2. Artist name + album name (2 fields)
3. Upload audio and artwork via Blossom (primal.net + nostr.download)
4. One-click Host on MSP (album + publisher feed, cross-linked)

Shows automatically on first visit; skipped for returning users who
have existing data. Re-accessible via New → New Artist (Guided).

Ports BlossomFileUpload component and uploadMediaToBlossom() from the
Blossom-Hosting branch, and hostBothOnMSP() from the onboarding-guide
branch. Both utilities are ported cleanly onto the master base.

Co-Authored-By: Claude <claude@anthropic.com>