### PR TITLE
Fix Primal remote signer blocking Nostr music import

### DIFF
--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -59,15 +59,14 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
   }, [showExperimental, mode]);
 
   const fetchSavedAlbums = async () => {
-    setLoadingAlbums(true);
-    setError('');
-    const health = await checkSignerConnection();
-    if (!health.connected) {
-      setError(health.error ?? 'Nostr signer is not connected.');
-      setLoadingAlbums(false);
+    const pubkey = nostrState.user?.pubkey;
+    if (!pubkey) {
+      setError('Not logged in to Nostr.');
       return;
     }
-    const result = await loadAlbumsFromNostr();
+    setLoadingAlbums(true);
+    setError('');
+    const result = await loadAlbumsFromNostr(pubkey);
     setLoadingAlbums(false);
 
     if (result.success) {
@@ -111,17 +110,15 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
   };
 
   const handleLoadFromNostr = async (dTag: string) => {
+    const pubkey = nostrState.user?.pubkey;
+    if (!pubkey) {
+      setError('Not logged in to Nostr.');
+      return;
+    }
     setLoading(true);
     setError('');
 
-    const health = await checkSignerConnection();
-    if (!health.connected) {
-      setError(health.error ?? 'Nostr signer is not connected.');
-      setLoading(false);
-      return;
-    }
-
-    const result = await loadAlbumByDTag(dTag);
+    const result = await loadAlbumByDTag(dTag, pubkey);
 
     if (result.success && result.album) {
       onClose();
@@ -134,17 +131,15 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
 
 
   const fetchMusicTracks = async () => {
+    const pubkey = nostrState.user?.pubkey;
+    if (!pubkey) {
+      setError('Not logged in to Nostr.');
+      return;
+    }
     setLoadingMusic(true);
     setError('');
 
-    const health = await checkSignerConnection();
-    if (!health.connected) {
-      setError(health.error ?? 'Nostr signer is not connected.');
-      setLoadingMusic(false);
-      return;
-    }
-
-    const result = await fetchNostrMusicTracks();
+    const result = await fetchNostrMusicTracks(pubkey);
     setLoadingMusic(false);
 
     if (result.success) {

--- a/src/components/modals/NostrConnectModal.tsx
+++ b/src/components/modals/NostrConnectModal.tsx
@@ -169,7 +169,7 @@ export function NostrConnectModal({ onClose }: NostrConnectModalProps) {
             {!connectUri ? (
               <>
                 <p className="connect-description">
-                  Connect using a remote signer like Amber (Android), Nostr Signer (iOS), or any NIP-46 compatible app.
+                  Connect using a remote signer like Primal (iOS/Android), Amber (Android), or any NIP-46 compatible app.
                 </p>
 
                 <div className="connect-option">

--- a/src/store/nostrStore.tsx
+++ b/src/store/nostrStore.tsx
@@ -149,16 +149,25 @@ export function NostrProvider({ children }: { children: ReactNode }) {
               console.log('[Nostr] reconnectNip46 returned:', pubkey);
               if (pubkey && pubkey === storedUser.pubkey) {
                 dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
-
                 refreshProfile(pubkey);
                 return;
               }
             } catch (e) {
               console.error('[Nostr] Failed to reconnect NIP-46:', e);
             }
+            // Reconnect failed — if credentials are still stored it was a timeout
+            // (reconnectNip46 only clears credentials for auth errors, not timeouts).
+            // Restore the UI session so the user appears logged in; read-only operations
+            // use the stored pubkey directly, and the signer will re-connect on the next
+            // signing operation via checkSignerConnection().
+            if (loadBunkerPointer()) {
+              console.log('[Nostr] Reconnect timed out, restoring session from stored data');
+              dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
+              return;
+            }
           }
-          // Failed to reconnect, clear stored session
-          console.log('[Nostr] Reconnection failed, clearing stored session');
+          // Credentials were cleared (auth error) — fully log out
+          console.log('[Nostr] Reconnection failed (auth error), clearing stored session');
           clearStoredUser();
           clearSigner();
           dispatch({ type: 'SET_LOADING', payload: false });

--- a/src/utils/nostrSigner.ts
+++ b/src/utils/nostrSigner.ts
@@ -231,6 +231,13 @@ export async function reconnectNip46(timeoutMs: number = 10000): Promise<string 
   const clientSk = getClientSecretKey();
   const pool = new SimplePool();
 
+  // Close the existing signer before creating a new one to avoid leaking pool connections
+  if (currentSigner?.close) {
+    try { currentSigner.close(); } catch { /* ignore close errors */ }
+  }
+  currentSigner = null;
+  currentMethod = null;
+
   try {
     // Create bunker pointer with proper format
     const bunkerPointer: BunkerPointer = {
@@ -290,7 +297,7 @@ export async function signEventWithTimeout(
     new Promise<never>((_, reject) =>
       setTimeout(
         () => reject(new Error(
-          'Signer request timed out. If you use a remote signer app (like Amber or nsecBunker), please open it and approve the pending request, then try again.'
+          'Signer request timed out. If you use a remote signer app (Primal, Amber, nsecBunker), please open it and approve the pending request, then try again.'
         )),
         effectiveTimeout
       )
@@ -309,7 +316,7 @@ export async function getPublicKeyWithTimeout(timeoutMs?: number): Promise<strin
     new Promise<never>((_, reject) =>
       setTimeout(
         () => reject(new Error(
-          'Signer request timed out. If you use a remote signer app (like Amber or nsecBunker), please open it and approve the pending request, then try again.'
+          'Signer request timed out. If you use a remote signer app (Primal, Amber, nsecBunker), please open it and approve the pending request, then try again.'
         )),
         effectiveTimeout
       )
@@ -320,19 +327,29 @@ export async function getPublicKeyWithTimeout(timeoutMs?: number): Promise<strin
 // Check whether the signer is reachable before starting a Nostr operation.
 // Returns { connected: true } quickly or { connected: false, error } without throwing.
 export async function checkSignerConnection(timeoutMs?: number): Promise<{ connected: boolean; error?: string }> {
+  const method = currentMethod ?? loadConnectionMethod();
+
   if (!hasSigner()) {
+    // If credentials are stored but the signer isn't initialized (e.g. reconnect timed out
+    // on page load), try to reconnect now so the user doesn't have to log in again.
+    if (method === 'nip46' && loadBunkerPointer()) {
+      const pubkey = await reconnectNip46(timeoutMs ?? 10_000);
+      if (pubkey) return { connected: true };
+      return {
+        connected: false,
+        error: 'Could not reach your remote signer. Open your signer app (Primal, Amber, nsecBunker) and try again.'
+      };
+    }
     return { connected: false, error: 'Not logged in to Nostr. Please log in and try again.' };
   }
 
-  const method = currentMethod;
-
   try {
     if (method === 'nip46') {
-      const pubkey = await reconnectNip46(timeoutMs ?? 5_000);
+      const pubkey = await reconnectNip46(timeoutMs ?? 10_000);
       if (!pubkey) {
         return {
           connected: false,
-          error: 'Could not reach your remote signer. Make sure the signer app is open and connected, then try again.'
+          error: 'Could not reach your remote signer. Open your signer app (Primal, Amber, nsecBunker) and try again.'
         };
       }
       return { connected: true };

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -208,14 +208,14 @@ export async function saveFeedToNostr(
 
 // Load saved albums from Nostr relays
 export async function loadAlbumsFromNostr(
+  pubkey: string,
   relays = DEFAULT_RELAYS
 ): Promise<{ success: boolean; albums: SavedAlbumInfo[]; message: string }> {
-  if (!hasSigner()) {
+  if (!pubkey) {
     return { success: false, albums: [], message: 'Not logged in' };
   }
 
   try {
-    const pubkey = await getPublicKeyWithTimeout();
     const allEvents: NostrEvent[] = [];
 
     // Query each relay
@@ -286,14 +286,14 @@ export async function loadAlbumsFromNostr(
 // Load a specific album by d tag
 export async function loadAlbumByDTag(
   dTag: string,
+  pubkey: string,
   relays = DEFAULT_RELAYS
 ): Promise<{ success: boolean; album: Album | null; message: string }> {
-  if (!hasSigner()) {
+  if (!pubkey) {
     return { success: false, album: null, message: 'Not logged in' };
   }
 
   try {
-    const pubkey = await getPublicKeyWithTimeout();
     let latestEvent: NostrEvent | null = null;
 
     // Query each relay
@@ -378,14 +378,14 @@ export function groupTracksByAlbum(tracks: NostrMusicTrackInfo[]): NostrMusicAlb
 
 // Fetch music track events (kind 36787) for logged-in user
 export async function fetchNostrMusicTracks(
+  pubkey: string,
   relays = MUSIC_RELAYS
 ): Promise<{ success: boolean; tracks: NostrMusicTrackInfo[]; message: string }> {
-  if (!hasSigner()) {
+  if (!pubkey) {
     return { success: false, tracks: [], message: 'Not logged in' };
   }
 
   try {
-    const pubkey = await getPublicKeyWithTimeout();
     const allEvents: NostrEvent[] = [];
 
     // Query each relay


### PR DESCRIPTION
Read-only operations (import from Nostr, import from Nostr Music, load
saved album) were gated behind checkSignerConnection(), which performs a
full NIP-46 re-handshake with the remote signer. On iOS, Primal is
backgrounded and can't respond within the 5-second window, so users saw
"Could not reach your remote signer" even though their login was valid.

Fixes:
- fetchNostrMusicTracks, loadAlbumsFromNostr, loadAlbumByDTag now accept
  a pubkey parameter directly; no signer connection needed for reads.
  ImportModal passes nostrState.user.pubkey, bypassing the pre-flight.
- reconnectNip46 closes the existing signer/pool before creating a new
  one, fixing a WebSocket pool leak on every checkSignerConnection call.
- Session restore no longer calls clearSigner() on a reconnect timeout:
  credentials are preserved and the UI session is restored from stored
  data so the user stays "logged in"; the signer reconnects lazily on
  the first signing operation.
- checkSignerConnection timeout raised from 5 s to 10 s for NIP-46 and
  now falls back to a reconnect attempt when currentSigner is null but
  stored credentials exist (covers the lazy-restore path).
- Error messages and NostrConnectModal now mention Primal by name.

Co-Authored-By: claude <noreply@anthropic.com>