### PR TITLE
Harden security and performance across API and frontend

### DIFF
--- a/api/_utils/adminAuth.ts
+++ b/api/_utils/adminAuth.ts
@@ -69,7 +69,13 @@ export async function verifyNostrEvent(event: NostrEvent): Promise<boolean> {
 // Check if pubkey is in admin list
 export function isAdminPubkey(pubkey: string): boolean {
   const adminPubkeys = process.env.MSP_ADMIN_PUBKEYS || '';
-  const allowedPubkeys = adminPubkeys.split(',').map(p => p.trim().toLowerCase());
+  const allowedPubkeys = adminPubkeys
+    .split(',')
+    .map(p => p.trim().toLowerCase())
+    .filter(Boolean);
+  if (allowedPubkeys.length === 0) {
+    return false;
+  }
   return allowedPubkeys.includes(pubkey.toLowerCase());
 }
 

--- a/api/_utils/feedUtils.test.ts
+++ b/api/_utils/feedUtils.test.ts
@@ -98,3 +98,27 @@ describe('notifyPodping', () => {
     expect(result.error).toBe('ECONNREFUSED');
   });
 });
+
+describe('timingSafeEqualHex', () => {
+  it('returns true for identical hex strings', async () => {
+    const { timingSafeEqualHex, hashToken } = await import('./feedUtils');
+    const h = hashToken('some-secret-token');
+    expect(timingSafeEqualHex(h, h)).toBe(true);
+  });
+
+  it('returns false for differing hex strings of equal length', async () => {
+    const { timingSafeEqualHex, hashToken } = await import('./feedUtils');
+    expect(timingSafeEqualHex(hashToken('a'), hashToken('b'))).toBe(false);
+  });
+
+  it('returns false for length mismatch without throwing', async () => {
+    const { timingSafeEqualHex } = await import('./feedUtils');
+    expect(timingSafeEqualHex('abcd', 'abcdef')).toBe(false);
+  });
+
+  it('returns false for non-string input', async () => {
+    const { timingSafeEqualHex } = await import('./feedUtils');
+    // @ts-expect-error testing defensive runtime guard
+    expect(timingSafeEqualHex(undefined, 'abcd')).toBe(false);
+  });
+});

--- a/api/_utils/feedUtils.ts
+++ b/api/_utils/feedUtils.ts
@@ -1,6 +1,6 @@
 // Shared API utilities for hosted feed endpoints
 import type { VercelRequest } from '@vercel/node';
-import { createHash } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 import { getAuthHeaders } from './podcastIndex.js';
 
 const PI_API_KEY = process.env.PODCASTINDEX_API_KEY;
@@ -189,6 +189,22 @@ export function getBaseUrl(req: VercelRequest): string {
  */
 export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Constant-time comparison of two hex strings (e.g. token hashes).
+ * Returns false on any length mismatch without leaking timing on the contents.
+ */
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {
+    return false;
+  }
+  const bufA = Buffer.from(a, 'hex');
+  const bufB = Buffer.from(b, 'hex');
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
 }
 
 /**

--- a/api/feed/[npub]/[guid].ts
+++ b/api/feed/[npub]/[guid].ts
@@ -201,7 +201,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Redirect to the Blossom URL
     return res.redirect(302, feedUrl);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    return res.status(500).json({ error: message });
+    console.error('Error resolving feed pointer:', error);
+    return res.status(500).json({ error: 'Failed to resolve feed' });
   }
 }

--- a/api/hosted/[feedId].ts
+++ b/api/hosted/[feedId].ts
@@ -5,6 +5,7 @@ import {
   notifyPodcastIndex,
   getBaseUrl,
   hashToken,
+  timingSafeEqualHex,
   isValidFeedId
 } from '../_utils/feedUtils.js';
 import { extractPodcastMedium } from '../_utils/xmlUtils.js';
@@ -244,7 +245,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           // Try token auth first
           if (editToken && typeof editToken === 'string') {
             const providedHash = hashToken(editToken);
-            if (storedHash === providedHash) {
+            if (timingSafeEqualHex(storedHash, providedHash)) {
               isAuthorized = true;
             }
           }
@@ -346,7 +347,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         // Validate token
         const providedHash = hashToken(editToken);
-        if (metadata.editTokenHash !== providedHash) {
+        if (!timingSafeEqualHex(metadata.editTokenHash, providedHash)) {
           return res.status(403).json({ error: 'Invalid edit token' });
         }
 
@@ -397,7 +398,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           // For legacy feeds without metadata, allow deletion with any token
           // (can't verify, but feed is unusable anyway)
           if (metadata) {
-            if (metadata.editTokenHash !== providedHash) {
+            if (!timingSafeEqualHex(metadata.editTokenHash, providedHash)) {
               return res.status(403).json({ error: 'Invalid edit token' });
             }
           }
@@ -433,7 +434,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
   } catch (error) {
     console.error('Error handling hosted feed:', error);
-    const message = error instanceof Error ? error.message : 'Operation failed';
-    return res.status(500).json({ error: message });
+    return res.status(500).json({ error: 'Operation failed' });
   }
 }

--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -212,7 +212,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
   } catch (error) {
     console.error('Error creating hosted feed:', error);
-    const message = error instanceof Error ? error.message : 'Failed to create feed';
-    return res.status(500).json({ error: message });
+    return res.status(500).json({ error: 'Failed to create feed' });
   }
 }

--- a/api/proxy-feed.test.ts
+++ b/api/proxy-feed.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function createMockReqRes(method: string, query: Record<string, string | undefined>) {
+  const req = { method, query, body: undefined, headers: {} } as any;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis(),
+    setHeader: vi.fn().mockReturnThis()
+  } as any;
+  return { req, res };
+}
+
+describe('/api/proxy-feed SSRF guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns 400 when url is missing', async () => {
+    const { default: handler } = await import('./proxy-feed');
+    const { req, res } = createMockReqRes('GET', {});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-http(s) protocols', async () => {
+    const { default: handler } = await import('./proxy-feed');
+    const { req, res } = createMockReqRes('GET', { url: 'file:///etc/passwd' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('blocks loopback addresses (403)', async () => {
+    const { default: handler } = await import('./proxy-feed');
+    const { req, res } = createMockReqRes('GET', { url: 'http://127.0.0.1/feed.xml' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('blocks the cloud-metadata link-local address (403)', async () => {
+    const { default: handler } = await import('./proxy-feed');
+    const { req, res } = createMockReqRes('GET', { url: 'http://169.254.169.254/latest/meta-data/' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('blocks private RFC1918 ranges (403)', async () => {
+    const { default: handler } = await import('./proxy-feed');
+    for (const host of ['http://10.0.0.5/x', 'http://192.168.1.1/x', 'http://172.16.0.1/x']) {
+      const { req, res } = createMockReqRes('GET', { url: host });
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(403);
+    }
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects public but unlisted domains (403)', async () => {
+    const { default: handler } = await import('./proxy-feed');
+    const { req, res } = createMockReqRes('GET', { url: 'https://evil.example.com/feed.xml' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('allows an allowlisted podcast host', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => '<?xml version="1.0"?><rss></rss>',
+      headers: { get: () => 'application/xml' }
+    });
+    const { default: handler } = await import('./proxy-feed');
+    const { req, res } = createMockReqRes('GET', { url: 'https://feeds.megaphone.fm/show.xml' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/proxy-feed.ts
+++ b/api/proxy-feed.ts
@@ -1,6 +1,40 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 /**
+ * True when a hostname points at a private, loopback, or link-local address —
+ * the targets an SSRF attacker would aim at (cloud metadata, internal services).
+ * String-based check on the literal host; covers IPv4 literals, IPv6 loopback,
+ * and obvious internal names. Hostnames that resolve to private IPs via DNS are
+ * not caught here, but combined with the domain allowlist below the surface is small.
+ */
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, ''); // strip IPv6 brackets
+
+  if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.local')) {
+    return true;
+  }
+
+  // IPv6 loopback / unique-local / link-local
+  if (host === '::1' || host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80:')) {
+    return true;
+  }
+
+  // IPv4 literal checks
+  const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const [a, b] = ipv4.slice(1).map(Number);
+    if (a === 10) return true;                       // 10.0.0.0/8
+    if (a === 127) return true;                      // loopback
+    if (a === 0) return true;                        // 0.0.0.0/8
+    if (a === 169 && b === 254) return true;         // link-local (cloud metadata)
+    if (a === 172 && b >= 16 && b <= 31) return true;// 172.16.0.0/12
+    if (a === 192 && b === 168) return true;         // 192.168.0.0/16
+  }
+
+  return false;
+}
+
+/**
  * Server-side proxy to fetch feeds - avoids CORS issues
  * GET /api/proxy-feed?url=<encoded-url>
  */
@@ -31,7 +65,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid URL' });
   }
 
-  // Only allow fetching RSS/XML feeds from trusted domains
+  // Only allow http(s) — block file:, data:, gopher:, etc.
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    return res.status(400).json({ error: 'Unsupported URL protocol' });
+  }
+
+  // Reject requests aimed at private, loopback, or link-local hosts (SSRF guard).
+  if (isPrivateHost(parsedUrl.hostname)) {
+    return res.status(403).json({ error: 'Domain not allowed' });
+  }
+
+  // Only allow fetching RSS/XML feeds from trusted podcast-host domains.
   const allowedDomains = [
     'msp.podtards.com',
     'feeds.podcastindex.org',
@@ -48,8 +92,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     'podbean.com',
     'spreaker.com',
     'audioboom.com',
-    'soundcloud.com',
-    'localhost'
+    'soundcloud.com'
   ];
 
   const isDomainAllowed = allowedDomains.some(domain =>
@@ -57,8 +100,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   );
 
   if (!isDomainAllowed) {
-    // For unlisted domains, still allow but log it
-    console.log(`Proxy fetch from unlisted domain: ${parsedUrl.hostname}`);
+    return res.status(403).json({ error: 'Domain not allowed' });
   }
 
   try {
@@ -87,7 +129,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(200).send(content);
   } catch (error) {
     console.error('Proxy fetch error:', error);
-    const message = error instanceof Error ? error.message : 'Failed to fetch';
-    return res.status(500).json({ error: message });
+    return res.status(502).json({ error: 'Failed to fetch feed' });
   }
 }

--- a/src/components/Editor/PublisherEditor/DownloadCatalogSection.tsx
+++ b/src/components/Editor/PublisherEditor/DownloadCatalogSection.tsx
@@ -20,28 +20,32 @@ export function DownloadCatalogSection({ publisherFeed }: DownloadCatalogSection
   // Auto-populate URL from sourceUrl (imported URL) or MSP hosted URL
   // Check periodically in case user hosts from the reminder section above
   useEffect(() => {
-    const checkHostedUrl = () => {
-      if (!publisherFeedUrl) {
-        // First priority: use sourceUrl if the feed was imported from a URL
-        if (publisherFeed.sourceUrl) {
-          setPublisherFeedUrl(publisherFeed.sourceUrl);
-          return;
-        }
-        // Second priority: check if hosted on MSP
-        if (publisherFeed.podcastGuid) {
-          const hostedInfo = getHostedFeedInfo(publisherFeed.podcastGuid);
-          if (hostedInfo) {
-            setPublisherFeedUrl(buildHostedUrl(hostedInfo.feedId));
-          }
+    // Already resolved — nothing to poll for.
+    if (publisherFeedUrl) return;
+
+    const checkHostedUrl = (): boolean => {
+      // First priority: use sourceUrl if the feed was imported from a URL
+      if (publisherFeed.sourceUrl) {
+        setPublisherFeedUrl(publisherFeed.sourceUrl);
+        return true;
+      }
+      // Second priority: check if hosted on MSP (in case hosted from another section)
+      if (publisherFeed.podcastGuid) {
+        const hostedInfo = getHostedFeedInfo(publisherFeed.podcastGuid);
+        if (hostedInfo) {
+          setPublisherFeedUrl(buildHostedUrl(hostedInfo.feedId));
+          return true;
         }
       }
+      return false;
     };
 
-    // Check immediately
-    checkHostedUrl();
+    // Check immediately; only keep polling while the URL is still unresolved.
+    if (checkHostedUrl()) return;
 
-    // Check periodically (in case hosted from another section)
-    const interval = setInterval(checkHostedUrl, 1000);
+    const interval = setInterval(() => {
+      if (checkHostedUrl()) clearInterval(interval);
+    }, 2000);
     return () => clearInterval(interval);
   }, [publisherFeed.podcastGuid, publisherFeed.sourceUrl, publisherFeedUrl]);
 

--- a/src/store/feedStore.tsx
+++ b/src/store/feedStore.tsx
@@ -618,23 +618,25 @@ const FeedContext = createContext<FeedContextType | undefined>(undefined);
 export function FeedProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(feedReducer, initialState);
 
-  // Auto-save to localStorage whenever album changes
+  // Auto-save to localStorage, debounced so rapid edits (every keystroke produces
+  // a new state object) collapse into one write ~0.5s after the user pauses.
   useEffect(() => {
-    albumStorage.save(state.album);
+    const timer = setTimeout(() => albumStorage.save(state.album), 500);
+    return () => clearTimeout(timer);
   }, [state.album]);
 
-  // Auto-save video feed to localStorage
+  // Auto-save video feed to localStorage (debounced)
   useEffect(() => {
-    if (state.videoFeed) {
-      videoStorage.save(state.videoFeed);
-    }
+    if (!state.videoFeed) return;
+    const timer = setTimeout(() => videoStorage.save(state.videoFeed!), 500);
+    return () => clearTimeout(timer);
   }, [state.videoFeed]);
 
-  // Auto-save publisher feed to localStorage
+  // Auto-save publisher feed to localStorage (debounced)
   useEffect(() => {
-    if (state.publisherFeed) {
-      publisherStorage.save(state.publisherFeed);
-    }
+    if (!state.publisherFeed) return;
+    const timer = setTimeout(() => publisherStorage.save(state.publisherFeed!), 500);
+    return () => clearTimeout(timer);
   }, [state.publisherFeed]);
 
   return (

--- a/src/store/nostrStore.tsx
+++ b/src/store/nostrStore.tsx
@@ -128,7 +128,6 @@ export function NostrProvider({ children }: { children: ReactNode }) {
       // Check for stored session
       const storedUser = loadStoredUser();
       const storedMethod = loadConnectionMethod();
-      console.log('[Nostr] Init - storedUser:', storedUser?.npub, 'storedMethod:', storedMethod);
 
       // Check for NIP-07 extension
       // Wait a bit for extension to inject
@@ -141,12 +140,9 @@ export function NostrProvider({ children }: { children: ReactNode }) {
         if (storedMethod === 'nip46') {
           // Try to reconnect NIP-46
           const bunkerPointer = loadBunkerPointer();
-          console.log('[Nostr] Attempting NIP-46 reconnect, bunkerPointer:', !!bunkerPointer);
           if (bunkerPointer) {
             try {
-              console.log('[Nostr] Calling reconnectNip46...');
               const pubkey = await reconnectNip46();
-              console.log('[Nostr] reconnectNip46 returned:', pubkey);
               if (pubkey && pubkey === storedUser.pubkey) {
                 dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
                 refreshProfile(pubkey);
@@ -161,13 +157,11 @@ export function NostrProvider({ children }: { children: ReactNode }) {
             // use the stored pubkey directly, and the signer will re-connect on the next
             // signing operation via checkSignerConnection().
             if (loadBunkerPointer()) {
-              console.log('[Nostr] Reconnect timed out, restoring session from stored data');
               dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
               return;
             }
           }
           // Credentials were cleared (auth error) — fully log out
-          console.log('[Nostr] Reconnection failed (auth error), clearing stored session');
           clearStoredUser();
           clearSigner();
           dispatch({ type: 'SET_LOADING', payload: false });

--- a/src/utils/xmlGenerator.ts
+++ b/src/utils/xmlGenerator.ts
@@ -402,7 +402,7 @@ const generateTrackXml = (track: Track, album: Album, level: number): string => 
   lines.push(`${indent(level + 1)}<guid isPermaLink="false">${escapeXml(track.guid)}</guid>`);
 
   if (track.transcriptUrl) {
-    lines.push(`${indent(level + 1)}<podcast:transcript url="${escapeXml(track.transcriptUrl)}" type="${track.transcriptType || 'application/srt'}" />`);
+    lines.push(`${indent(level + 1)}<podcast:transcript url="${escapeXml(track.transcriptUrl)}" type="${escapeXml(track.transcriptType || 'application/srt')}" />`);
   }
 
   // Track artwork (falls back to album)
@@ -419,7 +419,7 @@ const generateTrackXml = (track: Track, album: Album, level: number): string => 
   // Enclosure (audio file)
   const fileLength = track.enclosureLength || '0';
   const enclosureUrl = album.op3 ? applyOp3Prefix(track.enclosureUrl, album.podcastGuid) : track.enclosureUrl;
-  lines.push(`${indent(level + 1)}<enclosure url="${escapeXml(enclosureUrl)}" length="${fileLength}" type="${track.enclosureType}"/>`);
+  lines.push(`${indent(level + 1)}<enclosure url="${escapeXml(enclosureUrl)}" length="${fileLength}" type="${escapeXml(track.enclosureType)}"/>`);
 
 
   // Duration


### PR DESCRIPTION
## Summary

A targeted hardening pass: three parallel audits (API, frontend, utils/build) surfaced ~40 candidate findings; each high-severity claim was verified against the actual code, false positives discarded, and only the confirmed low-risk fixes applied. No large refactors.

## Security
- **SSRF in `api/proxy-feed.ts`** (headline fix): the domain allowlist was computed but never enforced — the handler only logged unlisted domains, then fetched *any* URL. Now rejects unlisted domains (403), blocks private/loopback/link-local hosts (incl. the `169.254.169.254` cloud-metadata address), and restricts to http(s).
- **Constant-time token comparison** in `api/hosted/[feedId].ts` via a new `timingSafeEqualHex` helper, replacing `===`/`!==` on edit-token hashes.
- **Admin-pubkey parsing** (`adminAuth.ts`) filters empty entries so an unset `MSP_ADMIN_PUBKEYS` can't produce a matchable `['']`.
- **Error-message hygiene**: API catch blocks return generic strings instead of raw exception messages (server-side `console.error` kept).

## Performance
- **`feedStore.tsx`** debounces its three localStorage auto-save effects (500ms), so rapid typing no longer serializes the whole feed on every keystroke.
- **`DownloadCatalogSection.tsx`** stops its 1s busy-poll once the URL resolves and uses a 2s interval otherwise.

## Cleanup
- Removed debug `console.log`s in `nostrStore.tsx` that printed npubs/pubkeys.
- `escapeXml()` applied to import-sourced `enclosureType`/`transcriptType` MIME attributes.

## Verification
- 105 tests pass (11 new: SSRF guard + constant-time helper).
- `tsc -b && vite build` clean.
- Lint shows the same 28 pre-existing problems as `master` (zero introduced).

## Deliberately not changed
- **Admin-auth "bypass"** flagged by the audit was a false positive — `parseAuthHeader` correctly enforces `isAdminPubkey`.
- **CORS `*`** is intentional: public feed-read endpoints with header-based (not cookie) auth, so no CSRF surface.
- **In-memory rate limiter** is per-instance in serverless, but a real fix needs Redis/KV infra — out of scope.
- **Editor/SaveModal decomposition + memoization sweep** — left as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)