### PR TITLE
Detect Lightning addresses on import regardless of feed type attribute

### DIFF
--- a/src/utils/xmlParser.test.ts
+++ b/src/utils/xmlParser.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { parseRssFeed } from './xmlParser';
+import { generateRssFeed } from './xmlGenerator';
 
 // Helper to build minimal RSS XML for testing
 function buildRssXml(enclosureUrl: string, podcastGuid?: string): string {
@@ -136,5 +137,77 @@ describe('Person tag merging with npub', () => {
 
     expect(album.persons).toHaveLength(1);
     expect(album.persons[0].npub).toBeUndefined();
+  });
+});
+
+describe('value recipient type detection on import', () => {
+  // Build a minimal RSS feed with a channel-level value block whose recipients
+  // are provided verbatim. Mirrors feeds produced by the old node-only tool.
+  function buildRssWithValueBlock(recipients: string, method = 'keysend'): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:podcast="https://podcastindex.org/namespace/1.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <itunes:author>Test Artist</itunes:author>
+    <description>A test feed</description>
+    <language>en</language>
+    <podcast:medium>music</podcast:medium>
+    <podcast:guid>test-guid</podcast:guid>
+    <podcast:value type="lightning" method="${method}" suggested="0.00000005000">
+      ${recipients}
+    </podcast:value>
+    <item>
+      <title>Track 1</title>
+      <guid isPermaLink="false">track-guid-1</guid>
+      <enclosure url="https://example.com/track1.mp3" length="1234" type="audio/mpeg"/>
+      <itunes:duration>03:45</itunes:duration>
+    </item>
+  </channel>
+</rss>`;
+  }
+
+  const NODE_PUBKEY = '035ad2c954e264004986da2d9499e1732e5175e1dcef2453c921c6cdcc3536e9d8';
+
+  it('corrects type="node" to "lnaddress" when the address contains @', () => {
+    const xml = buildRssWithValueBlock(
+      `<podcast:valueRecipient name="gless" type="node" address="gless@coinos.io" split="99"/>`
+    );
+
+    const album = parseRssFeed(xml);
+
+    expect(album.value.recipients[0].type).toBe('lnaddress');
+  });
+
+  it('keeps type="node" for a node pubkey address', () => {
+    const xml = buildRssWithValueBlock(
+      `<podcast:valueRecipient name="Node" type="node" address="${NODE_PUBKEY}" split="1"/>`
+    );
+
+    const album = parseRssFeed(xml);
+
+    expect(album.value.recipients[0].type).toBe('node');
+  });
+
+  it('detects lnaddress when the type attribute is missing entirely', () => {
+    const xml = buildRssWithValueBlock(
+      `<podcast:valueRecipient name="gless" address="gless@coinos.io" split="99"/>`
+    );
+
+    const album = parseRssFeed(xml);
+
+    expect(album.value.recipients[0].type).toBe('lnaddress');
+  });
+
+  it('round-trips a node-only feed into method="lnaddress" output', () => {
+    const xml = buildRssWithValueBlock(
+      `<podcast:valueRecipient name="Node" type="node" address="${NODE_PUBKEY}" split="1"/>
+       <podcast:valueRecipient name="gless" type="node" address="gless@coinos.io" split="99"/>`
+    );
+
+    const album = parseRssFeed(xml);
+    const regenerated = generateRssFeed(album);
+
+    expect(regenerated).toContain('method="lnaddress"');
+    expect(regenerated).toContain('address="gless@coinos.io" split="99" type="lnaddress"');
   });
 });

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -3,6 +3,7 @@ import { XMLParser } from 'fast-xml-parser';
 import type { Album, Track, Person, PersonGroup, ValueRecipient, ValueBlock, Funding, PublisherFeed, RemoteItem, PublisherReference, BaseChannelData } from '../types/feed';
 import { createEmptyTrack } from '../types/feed';
 import { areValueBlocksStrictEqual, arePersonsEqual } from './comparison';
+import { detectAddressType } from './addressUtils';
 
 // OP3 prefix pattern: https://op3.dev/e/ or https://op3.dev/e,pg=GUID/
 export const OP3_PREFIX_RE = /^https:\/\/op3\.dev\/e(?:,[^/]*)?\//;
@@ -321,11 +322,18 @@ function parseFunding(node: unknown): Funding | null {
 function parseRecipient(node: unknown): ValueRecipient | null {
   if (!node) return null;
 
+  // Derive the type from the address rather than trusting the XML's `type`
+  // attribute: older tools (e.g. the original musicsideproject.com) only knew
+  // about Lightning nodes and wrote type="node" even for Lightning addresses.
+  // An address containing "@" is always a Lightning address. This mirrors the
+  // auto-detection the editor UI applies on manual edit (RecipientsList.tsx).
+  const address = getAttr(node, 'address') || '';
+
   return {
     name: getAttr(node, 'name') || '',
-    address: getAttr(node, 'address') || '',
+    address,
     split: parseInt(getAttr(node, 'split')) || 0,
-    type: (getAttr(node, 'type') || 'node') as 'node' | 'lnaddress',
+    type: address ? detectAddressType(address) : 'node',
     customKey: getAttr(node, 'customKey') || undefined,
     customValue: getAttr(node, 'customValue') || undefined
   };


### PR DESCRIPTION
## Problem

A user imported a feed (`https://top-hits.thesenoises.online/tracks/image%20ep.xml`) created by an older node-only tool (the original musicsideproject.com). That tool only supported Lightning **nodes** (keysend) and had no concept of Lightning Addresses, so it wrote `type="node"` even for a recipient whose address is clearly a Lightning Address:

```xml
<podcast:valueRecipient name="gless" type="node" address="gless@coinos.io" split="99"/>
```

On import, MSP trusted the XML's `type` attribute verbatim, so `gless@coinos.io` stuck as a keysend node recipient — payments would route incorrectly.

The editor already auto-detects the correct type when you *edit* an address in the UI (`RecipientsList.tsx` → `detectAddressType()`), but that logic never ran on import.

## Fix

`parseRecipient()` in `src/utils/xmlParser.ts` now derives the recipient `type` from its `address` using the existing `detectAddressType()` helper, overriding whatever the XML claims. An `@` in the address → `lnaddress`; otherwise → `node` (empty address falls back to `node`, matching the prior default). This is safe — node pubkeys are 66 hex chars and never contain `@`; Lightning addresses always do.

No export change needed: `xmlGenerator.ts` already recomputes the value block's `method` from recipient types, so a corrected feed re-exports with `method="lnaddress"` automatically.

## Tests

Added a `value recipient type detection on import` block to `src/utils/xmlParser.test.ts`:
- `type="node"` + `gless@coinos.io` → corrected to `lnaddress`
- `type="node"` + 66-hex pubkey → stays `node`
- missing `type` + `@` address → `lnaddress`
- round-trip: node-only feed re-exports as `method="lnaddress"` / `type="lnaddress"`

`npm run test` → 109/109 pass · `npm run build` clean · lint clean on changed files.

Re-importing affected feeds will fix them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)