### PR TITLE
Migrate legacy MSP 1.0 support node to MSP 2.0 lnaddress on import

### DIFF
--- a/src/types/feed.ts
+++ b/src/types/feed.ts
@@ -284,6 +284,14 @@ export const createSupportRecipients = (): ValueRecipient[] => [
   { name: 'Podcastindex.org', address: 'podcastindex@getalby.com', split: 1, type: 'lnaddress' },
 ];
 
+// Legacy MSP 1.0 support node. Feeds created by the original musicsideproject.com
+// paid this Lightning *node* pubkey; on import we migrate it to the MSP 2.0
+// lnaddress identity (preserving the split) so support payments keep flowing.
+export const LEGACY_MSP_NODE_PUBKEY =
+  '035ad2c954e264004986da2d9499e1732e5175e1dcef2453c921c6cdcc3536e9d8';
+
+export const MSP_SUPPORT_RECIPIENT = { name: 'MSP 2.0', address: 'chadf@getalby.com' } as const;
+
 export const isCommunitySupport = (r: ValueRecipient): boolean =>
   COMMUNITY_SUPPORT_RECIPIENTS.some(cs => cs.name === r.name && cs.address === r.address);
 

--- a/src/utils/xmlParser.test.ts
+++ b/src/utils/xmlParser.test.ts
@@ -166,7 +166,8 @@ describe('value recipient type detection on import', () => {
 </rss>`;
   }
 
-  const NODE_PUBKEY = '035ad2c954e264004986da2d9499e1732e5175e1dcef2453c921c6cdcc3536e9d8';
+  // A generic, non-MSP node pubkey (the legacy MSP pubkey would be migrated to an lnaddress).
+  const NODE_PUBKEY = '02aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899';
 
   it('corrects type="node" to "lnaddress" when the address contains @', () => {
     const xml = buildRssWithValueBlock(
@@ -209,5 +210,89 @@ describe('value recipient type detection on import', () => {
 
     expect(regenerated).toContain('method="lnaddress"');
     expect(regenerated).toContain('address="gless@coinos.io" split="99" type="lnaddress"');
+  });
+});
+
+describe('legacy MSP 1.0 recipient migration on import', () => {
+  const LEGACY_MSP_PUBKEY = '035ad2c954e264004986da2d9499e1732e5175e1dcef2453c921c6cdcc3536e9d8';
+
+  // RSS feed with a channel-level value block (raw recipients) and a track that
+  // optionally carries its own value block.
+  function buildRss(channelRecipients: string, trackRecipients?: string): string {
+    const trackValue = trackRecipients
+      ? `<podcast:value type="lightning" method="keysend">${trackRecipients}</podcast:value>`
+      : '';
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:podcast="https://podcastindex.org/namespace/1.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <itunes:author>Test Artist</itunes:author>
+    <description>A test feed</description>
+    <language>en</language>
+    <podcast:medium>music</podcast:medium>
+    <podcast:guid>test-guid</podcast:guid>
+    <podcast:value type="lightning" method="keysend">${channelRecipients}</podcast:value>
+    <item>
+      <title>Track 1</title>
+      <guid isPermaLink="false">track-guid-1</guid>
+      <enclosure url="https://example.com/track1.mp3" length="1234" type="audio/mpeg"/>
+      <itunes:duration>03:45</itunes:duration>
+      ${trackValue}
+    </item>
+  </channel>
+</rss>`;
+  }
+
+  it('swaps the old MSP node recipient to the MSP 2.0 lnaddress identity', () => {
+    const xml = buildRss(
+      `<podcast:valueRecipient name="Music Side Project" type="node" address="${LEGACY_MSP_PUBKEY}" split="1"/>`
+    );
+
+    const r = parseRssFeed(xml).value.recipients[0];
+
+    expect(r.name).toBe('MSP 2.0');
+    expect(r.address).toBe('chadf@getalby.com');
+    expect(r.type).toBe('lnaddress');
+  });
+
+  it('preserves the existing split when migrating', () => {
+    const xml = buildRss(
+      `<podcast:valueRecipient name="Music Side Project" type="node" address="${LEGACY_MSP_PUBKEY}" split="5"/>`
+    );
+
+    expect(parseRssFeed(xml).value.recipients[0].split).toBe(5);
+  });
+
+  it('matches the legacy pubkey case-insensitively', () => {
+    const xml = buildRss(
+      `<podcast:valueRecipient name="Whatever" type="node" address="${LEGACY_MSP_PUBKEY.toUpperCase()}" split="1"/>`
+    );
+
+    expect(parseRssFeed(xml).value.recipients[0].address).toBe('chadf@getalby.com');
+  });
+
+  it('leaves an unrelated node recipient untouched', () => {
+    const other = '02aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899';
+    const xml = buildRss(
+      `<podcast:valueRecipient name="Some Artist" type="node" address="${other}" split="1"/>`
+    );
+
+    const r = parseRssFeed(xml).value.recipients[0];
+
+    expect(r.name).toBe('Some Artist');
+    expect(r.address).toBe(other);
+    expect(r.type).toBe('node');
+  });
+
+  it('migrates the legacy recipient inside a track-level value block too', () => {
+    const xml = buildRss(
+      `<podcast:valueRecipient name="Artist" type="node" address="02aa" split="1"/>`,
+      `<podcast:valueRecipient name="Music Side Project" type="node" address="${LEGACY_MSP_PUBKEY}" split="1"/>`
+    );
+
+    const trackRecipient = parseRssFeed(xml).tracks[0].value?.recipients[0];
+
+    expect(trackRecipient?.address).toBe('chadf@getalby.com');
+    expect(trackRecipient?.type).toBe('lnaddress');
   });
 });

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -1,7 +1,7 @@
 // MSP 2.0 - XML Parser for importing Demu RSS Feeds
 import { XMLParser } from 'fast-xml-parser';
 import type { Album, Track, Person, PersonGroup, ValueRecipient, ValueBlock, Funding, PublisherFeed, RemoteItem, PublisherReference, BaseChannelData } from '../types/feed';
-import { createEmptyTrack } from '../types/feed';
+import { createEmptyTrack, LEGACY_MSP_NODE_PUBKEY, MSP_SUPPORT_RECIPIENT } from '../types/feed';
 import { areValueBlocksStrictEqual, arePersonsEqual } from './comparison';
 import { detectAddressType } from './addressUtils';
 
@@ -328,11 +328,24 @@ function parseRecipient(node: unknown): ValueRecipient | null {
   // An address containing "@" is always a Lightning address. This mirrors the
   // auto-detection the editor UI applies on manual edit (RecipientsList.tsx).
   const address = getAttr(node, 'address') || '';
+  const split = parseInt(getAttr(node, 'split')) || 0;
+
+  // Migrate the legacy MSP 1.0 support node to the MSP 2.0 lnaddress identity,
+  // preserving the split so support payments keep flowing after import. Match
+  // on the pubkey (unique, unforgeable) — not the name, which a user may rename.
+  if (address.toLowerCase() === LEGACY_MSP_NODE_PUBKEY) {
+    return {
+      name: MSP_SUPPORT_RECIPIENT.name,
+      address: MSP_SUPPORT_RECIPIENT.address,
+      split,
+      type: 'lnaddress'
+    };
+  }
 
   return {
     name: getAttr(node, 'name') || '',
     address,
-    split: parseInt(getAttr(node, 'split')) || 0,
+    split,
     type: address ? detectAddressType(address) : 'node',
     customKey: getAttr(node, 'customKey') || undefined,
     customValue: getAttr(node, 'customValue') || undefined


### PR DESCRIPTION
## Problem

Feeds created by the original musicsideproject.com (MSP 1.0) paid the MSP support recipient via a Lightning **node** pubkey:

```xml
<podcast:valueRecipient name="Music Side Project" type="node" address="035ad2c954...e9d8" split="1"/>
```

When such a feed is imported into MSP 2.0, that split still points at the dead node identity instead of the current MSP 2.0 Lightning Address — so support sats don't reach the project.

## Fix

`parseRecipient()` in `src/utils/xmlParser.ts` now detects the legacy MSP node pubkey and swaps the recipient to the MSP 2.0 identity — `MSP 2.0` / `chadf@getalby.com` / `lnaddress` — **preserving the existing split**. It matches on the pubkey (unique and unforgeable) rather than the name, and runs at the single recipient choke point so it covers the channel value block and every per-track value block.

New constants `LEGACY_MSP_NODE_PUBKEY` and `MSP_SUPPORT_RECIPIENT` in `src/types/feed.ts` are the single source of truth.

`customKey`/`customValue` (keysend-only) are dropped on migration since the result is an lnaddress.

## Verified against the real feed

Running `https://top-hits.thesenoises.online/tracks/image ep.xml` through the actual parser + generator:
- `Music Side Project` node → `MSP 2.0` / `chadf@getalby.com` / `lnaddress`, split `1` preserved (channel + both tracks)
- generated output uses `method="lnaddress"` and no longer contains the legacy pubkey

## Tests

Added a `legacy MSP 1.0 recipient migration on import` block to `xmlParser.test.ts`: swap correctness, split preservation, case-insensitive pubkey match, unrelated node untouched, track-level value block coverage.

`npm run test` → 114/114 pass · build clean · lint clean on changed files.

Re-importing affected feeds applies the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)