### PR TITLE
Add reason: 'update' to automatic podping fire-and-forget calls

### DIFF
--- a/api/_utils/feedUtils.ts
+++ b/api/_utils/feedUtils.ts
@@ -105,7 +105,7 @@ export async function notifyPodcastIndex(
 
   // Broadcast feed update via self-hosted hivepinger (no-ops without PODPING_ENDPOINT_URL + PODPING_BEARER_TOKEN).
   // Intentionally not awaited so PI submission isn't blocked; surface failures to function logs.
-  notifyPodping(feedUrl, { medium: options.medium }).then((result) => {
+  notifyPodping(feedUrl, { reason: 'update', medium: options.medium }).then((result) => {
     if (!result.ok) {
       console.warn(`Podping broadcast failed for ${feedUrl}: ${result.error ?? 'unknown'}`);
     }

--- a/api/pubnotify.ts
+++ b/api/pubnotify.ts
@@ -62,7 +62,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Broadcast a podping in parallel so indexers that watch Hive re-crawl too.
     // Fire-and-forget; Railway/hivepinger handles its own retries.
     if (isPodpingConfigured()) {
-      notifyPodping(url, { medium: podpingMedium }).then((result) => {
+      notifyPodping(url, { reason: 'update', medium: podpingMedium }).then((result) => {
         if (!result.ok) {
           console.warn(`Podping broadcast failed for ${url}: ${result.error ?? 'unknown'}`);
         }


### PR DESCRIPTION
Both pubnotify and notifyPodcastIndex were omitting the reason param,
leaving hivepinger to use its own default. Explicitly pass 'update'
to match the manual PodpingModal behavior and the Podping spec.

https://claude.ai/code/session_017s9VUqUnjpFX9pP1stCUVB