### PR TITLE
Add Google sign-in + managed Nostr keypair onboarding

### DIFF
--- a/api/_utils/authUtils.test.ts
+++ b/api/_utils/authUtils.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { userBlobPath, userBlobPrefix, buildStoredKeyRecord } from './authUtils';
+
+const GOOGLE_ID = '110248495921238986420';
+
+describe('userBlobPath / userBlobPrefix', () => {
+  it('userBlobPath is the full .json object name used for put()', () => {
+    const path = userBlobPath(GOOGLE_ID);
+    expect(path.startsWith('auth/users/')).toBe(true);
+    expect(path.endsWith('.json')).toBe(true);
+  });
+
+  it('userBlobPrefix has no extension so it matches addRandomSuffix output on list()', () => {
+    const prefix = userBlobPrefix(GOOGLE_ID);
+    expect(prefix.startsWith('auth/users/')).toBe(true);
+    expect(prefix.endsWith('.json')).toBe(false);
+  });
+
+  it('the prefix is a prefix of the deterministic path', () => {
+    expect(userBlobPath(GOOGLE_ID).startsWith(userBlobPrefix(GOOGLE_ID))).toBe(true);
+  });
+
+  it('the prefix matches a random-suffixed blob name (the list() lookup invariant)', () => {
+    // Vercel Blob addRandomSuffix inserts `-<random>` before the extension.
+    const prefix = userBlobPrefix(GOOGLE_ID);
+    const suffixed = `${prefix}-aB3xZ9.json`;
+    expect(suffixed.startsWith(prefix)).toBe(true);
+  });
+
+  it('is deterministic for the same id and distinct across ids', () => {
+    expect(userBlobPrefix(GOOGLE_ID)).toBe(userBlobPrefix(GOOGLE_ID));
+    expect(userBlobPrefix(GOOGLE_ID)).not.toBe(userBlobPrefix('999999999999999999999'));
+  });
+});
+
+describe('buildStoredKeyRecord', () => {
+  it('stores only non-PII key material', () => {
+    const record = buildStoredKeyRecord('pubkeyhex', 'encryptednsec', '2026-06-19T00:00:00.000Z');
+    expect(record).toEqual({
+      pubkey: 'pubkeyhex',
+      encryptedNsec: 'encryptednsec',
+      createdAt: '2026-06-19T00:00:00.000Z',
+    });
+  });
+
+  it('never includes PII fields (email / displayName / picture)', () => {
+    const record = buildStoredKeyRecord('pubkeyhex', 'encryptednsec', '2026-06-19T00:00:00.000Z') as Record<string, unknown>;
+    expect(Object.keys(record)).not.toContain('email');
+    expect(Object.keys(record)).not.toContain('displayName');
+    expect(Object.keys(record)).not.toContain('picture');
+  });
+});

--- a/api/_utils/authUtils.ts
+++ b/api/_utils/authUtils.ts
@@ -1,0 +1,110 @@
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import type { VercelRequest } from '@vercel/node';
+
+async function deriveEncryptionKey(userId: string): Promise<CryptoKey> {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) throw new Error('AUTH_SECRET is not configured');
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(secret), 'HKDF', false, ['deriveKey']
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: enc.encode(userId),
+      info: enc.encode('msp-managed-keypair-v1'),
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encryptNsec(sk: Uint8Array, userId: string): Promise<string> {
+  const key = await deriveEncryptionKey(userId);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, sk);
+  const combined = new Uint8Array(12 + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), 12);
+  return Buffer.from(combined).toString('base64');
+}
+
+export async function decryptNsec(encrypted: string, userId: string): Promise<Uint8Array> {
+  const key = await deriveEncryptionKey(userId);
+  const combined = Buffer.from(encrypted, 'base64');
+  const iv = combined.subarray(0, 12);
+  const ciphertext = combined.subarray(12);
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return new Uint8Array(plaintext);
+}
+
+export function userBlobPath(googleId: string): string {
+  const hash = bytesToHex(sha256(new TextEncoder().encode(googleId)));
+  return `auth/users/${hash}.json`;
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
+
+export async function signJwt(payload: Record<string, unknown>, expiresInSeconds = 30 * 86400): Promise<string> {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) throw new Error('AUTH_SECRET is not configured');
+  const now = Math.floor(Date.now() / 1000);
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify({ ...payload, iat: now, exp: now + expiresInSeconds })).toString('base64url');
+  const signingInput = `${header}.${body}`;
+  const key = await hmacKey(secret);
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingInput));
+  return `${signingInput}.${Buffer.from(sig).toString('base64url')}`;
+}
+
+export async function verifyJwt(token: string): Promise<Record<string, unknown>> {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) throw new Error('AUTH_SECRET is not configured');
+  const parts = token.split('.');
+  if (parts.length !== 3) throw new Error('Invalid JWT format');
+  const [header, body, sig] = parts;
+  const signingInput = `${header}.${body}`;
+  const key = await hmacKey(secret);
+  const valid = await crypto.subtle.verify(
+    'HMAC', key,
+    Buffer.from(sig, 'base64url'),
+    new TextEncoder().encode(signingInput)
+  );
+  if (!valid) throw new Error('Invalid JWT signature');
+  const payload = JSON.parse(Buffer.from(body, 'base64url').toString()) as Record<string, unknown>;
+  const exp = typeof payload.exp === 'number' ? payload.exp : 0;
+  if (exp < Math.floor(Date.now() / 1000)) throw new Error('JWT expired');
+  return payload;
+}
+
+export function getSessionToken(req: VercelRequest): string | null {
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) return null;
+  const cookies: Record<string, string> = {};
+  for (const part of cookieHeader.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx < 0) continue;
+    cookies[part.slice(0, eqIdx).trim()] = part.slice(eqIdx + 1).trim();
+  }
+  return cookies['msp-session'] ?? null;
+}
+
+export function sessionCookie(jwt: string, maxAgeSeconds = 30 * 86400): string {
+  return `msp-session=${jwt}; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAgeSeconds}; Path=/`;
+}
+
+export function clearSessionCookie(): string {
+  return 'msp-session=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/';
+}

--- a/api/_utils/authUtils.ts
+++ b/api/_utils/authUtils.ts
@@ -42,9 +42,35 @@ export async function decryptNsec(encrypted: string, userId: string): Promise<Ui
   return new Uint8Array(plaintext);
 }
 
-export function userBlobPath(googleId: string): string {
+// Unguessable prefix used to list() a user's keypair blob. Has no `.json`
+// extension so it still matches the name produced by put(addRandomSuffix: true),
+// which inserts `-<random>` before the extension.
+export function userBlobPrefix(googleId: string): string {
   const hash = bytesToHex(sha256(new TextEncoder().encode(googleId)));
-  return `auth/users/${hash}.json`;
+  return `auth/users/${hash}`;
+}
+
+// Deterministic object name passed to put(). With addRandomSuffix the stored
+// name becomes `${userBlobPath}` with `-<random>` inserted before `.json`.
+export function userBlobPath(googleId: string): string {
+  return `${userBlobPrefix(googleId)}.json`;
+}
+
+// The record persisted to Blob. Intentionally excludes PII (email / displayName
+// / picture): those are carried in the signed session JWT and re-fetched fresh
+// from Google on each login, so they must never sit in a public blob.
+export interface StoredKeyRecord {
+  pubkey: string;
+  encryptedNsec: string;
+  createdAt: string;
+}
+
+export function buildStoredKeyRecord(
+  pubkey: string,
+  encryptedNsec: string,
+  createdAt: string
+): StoredKeyRecord {
+  return { pubkey, encryptedNsec, createdAt };
 }
 
 async function hmacKey(secret: string): Promise<CryptoKey> {

--- a/api/auth/google-callback.ts
+++ b/api/auth/google-callback.ts
@@ -2,7 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 import { npubEncode } from 'nostr-tools/nip19';
 import { list, put } from '@vercel/blob';
-import { encryptNsec, decryptNsec, userBlobPath, signJwt, sessionCookie } from '../_utils/authUtils.js';
+import { encryptNsec, decryptNsec, userBlobPath, userBlobPrefix, buildStoredKeyRecord, signJwt, sessionCookie } from '../_utils/authUtils.js';
 
 interface GoogleTokenPayload {
   sub: string;
@@ -11,13 +11,10 @@ interface GoogleTokenPayload {
   picture?: string;
 }
 
+// Only the non-PII fields are read back; PII lives in the session JWT, not the blob.
 interface StoredKeyData {
   pubkey: string;
   encryptedNsec: string;
-  email: string;
-  displayName?: string;
-  picture?: string;
-  createdAt: string;
 }
 
 async function exchangeCodeForUser(
@@ -75,11 +72,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const { sub: googleId, email, name: displayName, picture } = await exchangeCodeForUser(code, redirectUri);
 
-    const blobPath = userBlobPath(googleId);
+    const blobPrefix = userBlobPrefix(googleId);
     let pubkey: string;
     let sk: Uint8Array | null = null;
 
-    const { blobs } = await list({ prefix: blobPath });
+    const { blobs } = await list({ prefix: blobPrefix });
 
     if (blobs.length > 0) {
       const blobRes = await fetch(blobs[0].url);
@@ -90,18 +87,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       sk = generateSecretKey();
       pubkey = getPublicKey(sk);
       const encryptedNsec = await encryptNsec(sk, googleId);
-      const data: StoredKeyData = {
-        pubkey,
-        encryptedNsec,
-        email,
-        displayName,
-        picture,
-        createdAt: new Date().toISOString(),
-      };
-      await put(blobPath, JSON.stringify(data), {
+      const data = buildStoredKeyRecord(pubkey, encryptedNsec, new Date().toISOString());
+      // Vercel Blob v2 only serves public blobs; addRandomSuffix gives the object
+      // an unguessable name so the keypair can't be fetched from a derived URL.
+      await put(userBlobPath(googleId), JSON.stringify(data), {
         access: 'public',
         contentType: 'application/json',
-        addRandomSuffix: false,
+        addRandomSuffix: true,
       });
     }
 

--- a/api/auth/google-callback.ts
+++ b/api/auth/google-callback.ts
@@ -1,0 +1,127 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { npubEncode } from 'nostr-tools/nip19';
+import { list, put } from '@vercel/blob';
+import { encryptNsec, decryptNsec, userBlobPath, signJwt, sessionCookie } from '../_utils/authUtils.js';
+
+interface GoogleTokenPayload {
+  sub: string;
+  email: string;
+  name?: string;
+  picture?: string;
+}
+
+interface StoredKeyData {
+  pubkey: string;
+  encryptedNsec: string;
+  email: string;
+  displayName?: string;
+  picture?: string;
+  createdAt: string;
+}
+
+async function exchangeCodeForUser(
+  code: string,
+  redirectUri: string
+): Promise<GoogleTokenPayload> {
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID!,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google token exchange failed: ${text}`);
+  }
+  const data = await res.json() as { id_token?: string };
+  if (!data.id_token) throw new Error('No id_token returned by Google');
+  // Decode payload (trusted — received directly from Google's token endpoint over HTTPS)
+  const [, payloadB64] = data.id_token.split('.');
+  return JSON.parse(Buffer.from(payloadB64, 'base64url').toString()) as GoogleTokenPayload;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const { code, state, error } = req.query as Record<string, string>;
+
+  if (error) {
+    return res.redirect(302, `/?auth_error=${encodeURIComponent(error)}`);
+  }
+  if (!code || !state) {
+    return res.redirect(302, '/?auth_error=missing_params');
+  }
+
+  // Validate CSRF state from cookie
+  const cookieHeader = req.headers.cookie ?? '';
+  const cookies: Record<string, string> = {};
+  for (const part of cookieHeader.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx < 0) continue;
+    cookies[part.slice(0, eqIdx).trim()] = part.slice(eqIdx + 1).trim();
+  }
+  if (!cookies['msp-oauth-state'] || cookies['msp-oauth-state'] !== state) {
+    return res.redirect(302, '/?auth_error=csrf_mismatch');
+  }
+
+  try {
+    const proto = (req.headers['x-forwarded-proto'] as string) ?? 'https';
+    const host = req.headers['host'] as string;
+    const redirectUri = `${proto}://${host}/api/auth/google-callback`;
+
+    const { sub: googleId, email, name: displayName, picture } = await exchangeCodeForUser(code, redirectUri);
+
+    const blobPath = userBlobPath(googleId);
+    let pubkey: string;
+    let sk: Uint8Array | null = null;
+
+    const { blobs } = await list({ prefix: blobPath });
+
+    if (blobs.length > 0) {
+      const blobRes = await fetch(blobs[0].url);
+      const stored = await blobRes.json() as StoredKeyData;
+      pubkey = stored.pubkey;
+      sk = await decryptNsec(stored.encryptedNsec, googleId);
+    } else {
+      sk = generateSecretKey();
+      pubkey = getPublicKey(sk);
+      const encryptedNsec = await encryptNsec(sk, googleId);
+      const data: StoredKeyData = {
+        pubkey,
+        encryptedNsec,
+        email,
+        displayName,
+        picture,
+        createdAt: new Date().toISOString(),
+      };
+      await put(blobPath, JSON.stringify(data), {
+        access: 'public',
+        contentType: 'application/json',
+        addRandomSuffix: false,
+      });
+    }
+
+    const npub = npubEncode(pubkey);
+    const jwt = await signJwt({
+      sub: googleId,
+      email,
+      pubkey,
+      npub,
+      displayName: displayName ?? email,
+      picture: picture ?? null,
+    });
+
+    res.setHeader('Set-Cookie', [
+      sessionCookie(jwt),
+      'msp-oauth-state=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/',
+    ]);
+    res.redirect(302, '/?auth=success');
+  } catch (err) {
+    console.error('[auth/google-callback]', err);
+    res.redirect(302, '/?auth_error=server_error');
+  }
+}

--- a/api/auth/google-start.ts
+++ b/api/auth/google-start.ts
@@ -1,0 +1,25 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    return res.status(503).send('Google sign-in is not configured');
+  }
+
+  const state = crypto.randomUUID();
+  const proto = (req.headers['x-forwarded-proto'] as string) ?? 'https';
+  const host = req.headers['host'] as string;
+  const redirectUri = `${proto}://${host}/api/auth/google-callback`;
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'openid email profile',
+    state,
+    prompt: 'select_account',
+  });
+
+  res.setHeader('Set-Cookie', `msp-oauth-state=${state}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/`);
+  res.redirect(302, `https://accounts.google.com/o/oauth2/v2/auth?${params}`);
+}

--- a/api/auth/keypair.ts
+++ b/api/auth/keypair.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { list } from '@vercel/blob';
 import { bytesToHex } from '@noble/hashes/utils';
-import { getSessionToken, verifyJwt, decryptNsec, userBlobPath } from '../_utils/authUtils.js';
+import { getSessionToken, verifyJwt, decryptNsec, userBlobPrefix } from '../_utils/authUtils.js';
 
 interface StoredKeyData {
   pubkey: string;
@@ -17,8 +17,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const payload = await verifyJwt(token);
     const googleId = payload.sub as string;
 
-    const blobPath = userBlobPath(googleId);
-    const { blobs } = await list({ prefix: blobPath });
+    const { blobs } = await list({ prefix: userBlobPrefix(googleId) });
     if (blobs.length === 0) {
       return res.status(404).json({ error: 'Keypair not found' });
     }

--- a/api/auth/keypair.ts
+++ b/api/auth/keypair.ts
@@ -1,0 +1,38 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { list } from '@vercel/blob';
+import { bytesToHex } from '@noble/hashes/utils';
+import { getSessionToken, verifyJwt, decryptNsec, userBlobPath } from '../_utils/authUtils.js';
+
+interface StoredKeyData {
+  pubkey: string;
+  encryptedNsec: string;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const token = getSessionToken(req);
+  if (!token) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  try {
+    const payload = await verifyJwt(token);
+    const googleId = payload.sub as string;
+
+    const blobPath = userBlobPath(googleId);
+    const { blobs } = await list({ prefix: blobPath });
+    if (blobs.length === 0) {
+      return res.status(404).json({ error: 'Keypair not found' });
+    }
+
+    const blobRes = await fetch(blobs[0].url);
+    const stored = await blobRes.json() as StoredKeyData;
+    const sk = await decryptNsec(stored.encryptedNsec, googleId);
+
+    return res.status(200).json({ sk: bytesToHex(sk) });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Server error';
+    if (message.includes('expired') || message.includes('Invalid') || message.includes('signature')) {
+      return res.status(401).json({ error: message });
+    }
+    return res.status(500).json({ error: 'Server error' });
+  }
+}

--- a/api/auth/logout.ts
+++ b/api/auth/logout.ts
@@ -1,0 +1,7 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { clearSessionCookie } from '../_utils/authUtils.js';
+
+export default async function handler(_req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Set-Cookie', clearSessionCookie());
+  return res.status(200).json({ ok: true });
+}

--- a/api/auth/me.ts
+++ b/api/auth/me.ts
@@ -1,0 +1,21 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSessionToken, verifyJwt } from '../_utils/authUtils.js';
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const token = getSessionToken(req);
+  if (!token) {
+    return res.status(401).json({ error: 'Not authenticated' });
+  }
+  try {
+    const payload = await verifyJwt(token);
+    return res.status(200).json({
+      pubkey: payload.pubkey,
+      npub: payload.npub,
+      email: payload.email,
+      displayName: payload.displayName,
+      picture: payload.picture,
+    });
+  } catch {
+    return res.status(401).json({ error: 'Invalid or expired session' });
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { PreviewModal } from './components/modals/PreviewModal';
 import { PodpingModal } from './components/modals/PodpingModal';
 import { InfoModal } from './components/modals/InfoModal';
 import { NostrConnectModal } from './components/modals/NostrConnectModal';
+import { ManagedKeyModal } from './components/modals/ManagedKeyModal';
 import { NewFeedChoiceModal } from './components/modals/NewFeedChoiceModal';
 import { Editor } from './components/Editor/Editor';
 import { PublisherEditor } from './components/Editor/PublisherEditor';
@@ -36,6 +37,7 @@ function AppContent() {
   const [showPodpingModal, setShowPodpingModal] = useState(false);
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [showNostrConnectModal, setShowNostrConnectModal] = useState(false);
+  const [showManagedKeyModal, setShowManagedKeyModal] = useState(false);
   const [showNewFeedChoiceModal, setShowNewFeedChoiceModal] = useState(false);
   const [pendingNewFeedType, setPendingNewFeedType] = useState<FeedType>('album');
   const [isTemplateMode, setIsTemplateMode] = useState(false);
@@ -228,18 +230,28 @@ function AppContent() {
                   </button>
                   <div className="dropdown-divider" />
                   {nostrState.isLoggedIn ? (
-                    <button
-                      className="dropdown-item"
-                      onClick={() => { nostrLogout(); setShowDropdown(false); }}
-                    >
-                      🚪 Sign Out (nostr)
-                    </button>
+                    <>
+                      <button
+                        className="dropdown-item"
+                        onClick={() => { nostrLogout(); setShowDropdown(false); }}
+                      >
+                        🚪 Sign Out{nostrState.connectionMethod !== 'managed' ? ' (nostr)' : ''}
+                      </button>
+                      {nostrState.connectionMethod === 'managed' && (
+                        <button
+                          className="dropdown-item"
+                          onClick={() => { setShowManagedKeyModal(true); setShowDropdown(false); }}
+                        >
+                          🔑 My Nostr Keys
+                        </button>
+                      )}
+                    </>
                   ) : (
                     <button
                       className="dropdown-item"
                       onClick={() => { setShowNostrConnectModal(true); setShowDropdown(false); }}
                     >
-                      🔑 Sign In (nostr)
+                      🔑 Sign In
                     </button>
                   )}
                   {/* Local dev only — gated on import.meta.env.DEV so it is tree-shaken out of production builds */}
@@ -366,6 +378,9 @@ function AppContent() {
 
       {showNostrConnectModal && (
         <NostrConnectModal onClose={() => setShowNostrConnectModal(false)} />
+      )}
+      {showManagedKeyModal && (
+        <ManagedKeyModal onClose={() => setShowManagedKeyModal(false)} />
       )}
 
       <NewFeedChoiceModal

--- a/src/components/modals/ManagedKeyModal.tsx
+++ b/src/components/modals/ManagedKeyModal.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { hexToBytes } from '@noble/hashes/utils';
+import { nsecEncode } from 'nostr-tools/nip19';
+import { useNostr } from '../../store/nostrStore';
+import { ModalWrapper } from './ModalWrapper';
+
+interface ManagedKeyModalProps {
+  onClose: () => void;
+}
+
+export function ManagedKeyModal({ onClose }: ManagedKeyModalProps) {
+  const { state } = useNostr();
+  const [nsecRevealed, setNsecRevealed] = useState(false);
+  const [nsec, setNsec] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [npubCopied, setNpubCopied] = useState(false);
+  const [nsecCopied, setNsecCopied] = useState(false);
+
+  const npub = state.user?.npub ?? '';
+
+  const handleReveal = async () => {
+    if (nsec) {
+      setNsecRevealed(true);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/auth/keypair');
+      if (!res.ok) {
+        setError('Could not retrieve key. Please sign in again.');
+        return;
+      }
+      const { sk: skHex } = await res.json() as { sk: string };
+      setNsec(nsecEncode(hexToBytes(skHex)));
+      setNsecRevealed(true);
+    } catch {
+      setError('Network error — please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleHide = () => setNsecRevealed(false);
+
+  const copy = async (text: string, setCopied: (v: boolean) => void) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <ModalWrapper
+      isOpen={true}
+      onClose={onClose}
+      title="Your Nostr Keys"
+      className="managed-key-modal"
+      footer={
+        <button className="btn btn-secondary" onClick={onClose}>Close</button>
+      }
+    >
+      <p style={{ marginBottom: '20px', color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+        Your Nostr identity was created automatically when you signed in with Google.
+        You can import these keys into any Nostr app.
+      </p>
+
+      <div className="key-field">
+        <label className="key-label">Public Key (npub) — safe to share</label>
+        <div className="key-value-row">
+          <code className="key-value">{npub}</code>
+          <button
+            className="btn btn-secondary btn-small"
+            onClick={() => copy(npub, setNpubCopied)}
+          >
+            {npubCopied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      <div className="key-field" style={{ marginTop: '20px' }}>
+        <label className="key-label">Private Key (nsec) — keep secret</label>
+        {!nsecRevealed ? (
+          <button
+            className="btn btn-secondary"
+            onClick={handleReveal}
+            disabled={loading}
+            style={{ marginTop: '8px' }}
+          >
+            {loading ? 'Loading...' : 'Reveal Private Key'}
+          </button>
+        ) : (
+          <>
+            <div className="key-value-row" style={{ marginTop: '8px' }}>
+              <code className="key-value">{nsec}</code>
+              <div style={{ display: 'flex', gap: '8px', flexShrink: 0 }}>
+                <button
+                  className="btn btn-secondary btn-small"
+                  onClick={() => copy(nsec!, setNsecCopied)}
+                >
+                  {nsecCopied ? 'Copied!' : 'Copy'}
+                </button>
+                <button className="btn btn-secondary btn-small" onClick={handleHide}>
+                  Hide
+                </button>
+              </div>
+            </div>
+            <div className="key-warning" style={{ marginTop: '12px' }}>
+              ⚠️ <strong>Keep this private.</strong> Anyone with this key controls your Nostr identity.
+              Never share it or paste it into untrusted websites.
+            </div>
+          </>
+        )}
+      </div>
+
+      {error && <div className="connect-error" style={{ marginTop: '12px' }}>{error}</div>}
+
+      <div className="key-tip" style={{ marginTop: '24px', padding: '12px', background: 'var(--bg-secondary)', borderRadius: '6px', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
+        <strong>Tip:</strong> Import your <code>nsec</code> into{' '}
+        <a href="https://primal.net" target="_blank" rel="noopener noreferrer">Primal</a>,{' '}
+        <a href="https://getalby.com" target="_blank" rel="noopener noreferrer">Alby</a>, or{' '}
+        <a href="https://fountain.fm" target="_blank" rel="noopener noreferrer">Fountain</a>{' '}
+        to use your identity across Nostr apps. Once imported, you can switch to "Remote Signer" login
+        instead of Google.
+      </div>
+    </ModalWrapper>
+  );
+}

--- a/src/components/modals/NostrConnectModal.tsx
+++ b/src/components/modals/NostrConnectModal.tsx
@@ -8,14 +8,11 @@ interface NostrConnectModalProps {
   onClose: () => void;
 }
 
-type Tab = 'extension' | 'remote';
+type Tab = 'google' | 'primal' | 'extension' | 'remote';
 
 export function NostrConnectModal({ onClose }: NostrConnectModalProps) {
-  const { state, login, loginWithNip46 } = useNostr();
-  const [tab, setTab] = useState<Tab>(() => {
-    // Default to remote on mobile (no extension), extension on desktop
-    return hasNip07Extension() ? 'extension' : 'remote';
-  });
+  const { state, login, loginWithNip46, loginWithGoogle } = useNostr();
+  const [tab, setTab] = useState<Tab>('google');
   const [bunkerUri, setBunkerUri] = useState('');
   const [connectUri, setConnectUri] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
@@ -24,36 +21,35 @@ export function NostrConnectModal({ onClose }: NostrConnectModalProps) {
 
   const hasExtension = hasNip07Extension();
 
-  // Generate QR code when connectUri changes
   useEffect(() => {
     if (connectUri && canvasRef.current) {
       QRCode.toCanvas(canvasRef.current, connectUri, {
         width: 256,
         margin: 2,
-        color: {
-          dark: '#000000',
-          light: '#ffffff',
-        },
-      }).catch(err => {
-        console.error('Failed to generate QR code:', err);
-      });
+        color: { dark: '#000000', light: '#ffffff' },
+      }).catch(err => console.error('Failed to generate QR code:', err));
     }
   }, [connectUri]);
 
-  // Close modal on successful login
   useEffect(() => {
     if (state.isLoggedIn && !state.isLoading) {
       onClose();
     }
   }, [state.isLoggedIn, state.isLoading, onClose]);
 
-  // Handle errors from state
   useEffect(() => {
     if (state.error) {
       setError(state.error);
       setConnecting(false);
     }
   }, [state.error]);
+
+  const changeTab = (t: Tab) => {
+    setTab(t);
+    setError(null);
+    setConnectUri(null);
+    setConnecting(false);
+  };
 
   const handleExtensionLogin = async () => {
     setError(null);
@@ -86,11 +82,8 @@ export function NostrConnectModal({ onClose }: NostrConnectModalProps) {
     setError(null);
     setConnecting(true);
     setConnectUri(null);
-
     try {
-      await loginWithNip46(undefined, (uri) => {
-        setConnectUri(uri);
-      });
+      await loginWithNip46(undefined, (uri) => setConnectUri(uri));
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Connection failed');
       setConnecting(false);
@@ -98,18 +91,16 @@ export function NostrConnectModal({ onClose }: NostrConnectModalProps) {
   };
 
   const handleCopyUri = async () => {
-    if (connectUri) {
-      try {
-        await navigator.clipboard.writeText(connectUri);
-      } catch {
-        // Fallback for older browsers
-        const textArea = document.createElement('textarea');
-        textArea.value = connectUri;
-        document.body.appendChild(textArea);
-        textArea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textArea);
-      }
+    if (!connectUri) return;
+    try {
+      await navigator.clipboard.writeText(connectUri);
+    } catch {
+      const el = document.createElement('textarea');
+      el.value = connectUri;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
     }
   };
 
@@ -123,129 +114,179 @@ export function NostrConnectModal({ onClose }: NostrConnectModalProps) {
     <ModalWrapper
       isOpen={true}
       onClose={onClose}
-      title="Sign in with Nostr"
+      title="Sign In"
       className="nostr-connect-modal"
       footer={
         <button className="btn btn-secondary" onClick={onClose}>Cancel</button>
       }
     >
       <div className="modal-tabs">
-        <button
-          className={`modal-tab ${tab === 'extension' ? 'active' : ''}`}
-          onClick={() => { setTab('extension'); setError(null); setConnectUri(null); }}
-        >
-          Browser Extension
+        <button className={`modal-tab ${tab === 'google' ? 'active' : ''}`} onClick={() => changeTab('google')}>
+          Quick Sign In
         </button>
-        <button
-          className={`modal-tab ${tab === 'remote' ? 'active' : ''}`}
-          onClick={() => { setTab('remote'); setError(null); setConnectUri(null); }}
-        >
+        <button className={`modal-tab ${tab === 'primal' ? 'active' : ''}`} onClick={() => changeTab('primal')}>
+          New to Nostr?
+        </button>
+        <button className={`modal-tab ${tab === 'extension' ? 'active' : ''}`} onClick={() => changeTab('extension')}>
+          Extension
+        </button>
+        <button className={`modal-tab ${tab === 'remote' ? 'active' : ''}`} onClick={() => changeTab('remote')}>
           Remote Signer
         </button>
       </div>
 
-      {tab === 'extension' ? (
+      {tab === 'google' && (
+        <div className="nostr-connect-google">
+          <p className="connect-description">
+            Sign in with Google and we'll create a Nostr identity for you automatically.
+            No Nostr knowledge required.
+          </p>
+          <button
+            className="btn btn-primary btn-large btn-google"
+            onClick={() => loginWithGoogle()}
+            style={{ display: 'flex', alignItems: 'center', gap: '10px', justifyContent: 'center' }}
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+              <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/>
+              <path d="M9 18c2.43 0 4.467-.806 5.956-2.184l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+              <path d="M3.964 10.706A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.706V4.962H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.038l3.007-2.332z" fill="#FBBC05"/>
+              <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.962L3.964 7.294C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+            </svg>
+            Continue with Google
+          </button>
+          <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginTop: '12px', textAlign: 'center' }}>
+            You can always export your Nostr keys later from the menu.
+          </p>
+        </div>
+      )}
+
+      {tab === 'primal' && (
+        <div className="nostr-connect-primal">
+          <p className="connect-description">
+            Primal is an easy way to get a real Nostr identity that works across many apps —
+            Fountain, Wavlake, Zap.stream, and more.
+          </p>
+          <div className="primal-steps">
+            <div className="primal-step">
+              <div className="primal-step-number">1</div>
+              <div className="primal-step-content">
+                <strong>Download Primal</strong>
+                <p>
+                  Get the app at{' '}
+                  <a href="https://primal.net" target="_blank" rel="noopener noreferrer">primal.net</a>
+                  {' '}— available on iOS, Android, and web.
+                </p>
+              </div>
+            </div>
+            <div className="primal-step">
+              <div className="primal-step-number">2</div>
+              <div className="primal-step-content">
+                <strong>Create your account</strong>
+                <p>Sign up with your email address or phone number in the Primal app.</p>
+              </div>
+            </div>
+            <div className="primal-step">
+              <div className="primal-step-number">3</div>
+              <div className="primal-step-content">
+                <strong>Get your connection code</strong>
+                <p>
+                  In Primal: <strong>Settings → Keys → Nostr Connect</strong> — copy the{' '}
+                  <code>bunker://</code> URI shown there.
+                </p>
+              </div>
+            </div>
+            <div className="primal-step">
+              <div className="primal-step-number">4</div>
+              <div className="primal-step-content">
+                <strong>Connect here</strong>
+                <p>
+                  Go to the <strong>Remote Signer</strong> tab above, paste your code, and connect.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {tab === 'extension' && (
         <div className="nostr-connect-extension">
-            <p className="connect-description">
-              Connect using a NIP-07 browser extension like Alby, nos2x, or Nostr Connect.
-            </p>
+          <p className="connect-description">
+            Connect using a NIP-07 browser extension like Alby, nos2x, or Nostr Connect.
+          </p>
+          {!hasExtension && (
+            <div className="connect-warning">
+              No Nostr extension detected. Install one to use this method, or use Remote Signer for mobile.
+            </div>
+          )}
+          <button
+            className="btn btn-primary btn-large"
+            onClick={handleExtensionLogin}
+            disabled={!hasExtension || connecting}
+          >
+            {connecting ? 'Connecting...' : 'Connect with Extension'}
+          </button>
+        </div>
+      )}
 
-            {!hasExtension && (
-              <div className="connect-warning">
-                No Nostr extension detected. Install one to use this method, or use Remote Signer for mobile.
+      {tab === 'remote' && (
+        <div className="nostr-connect-remote">
+          {!connectUri ? (
+            <>
+              <p className="connect-description">
+                Connect using a remote signer like Primal (iOS/Android), Amber (Android), or any NIP-46 compatible app.
+              </p>
+              <div className="connect-option">
+                <h4>Option 1: Scan QR Code</h4>
+                <p>Generate a connection QR code to scan with your signer app.</p>
+                <button className="btn btn-primary" onClick={handleGenerateQR} disabled={connecting}>
+                  {connecting ? 'Generating...' : 'Generate QR Code'}
+                </button>
               </div>
-            )}
-
-            <button
-              className="btn btn-primary btn-large"
-              onClick={handleExtensionLogin}
-              disabled={!hasExtension || connecting}
-            >
-              {connecting ? 'Connecting...' : 'Connect with Extension'}
-            </button>
-          </div>
-        ) : (
-          <div className="nostr-connect-remote">
-            {!connectUri ? (
-              <>
-                <p className="connect-description">
-                  Connect using a remote signer like Primal (iOS/Android), Amber (Android), or any NIP-46 compatible app.
-                </p>
-
-                <div className="connect-option">
-                  <h4>Option 1: Scan QR Code</h4>
-                  <p>Generate a connection QR code to scan with your signer app.</p>
-                  <button
-                    className="btn btn-primary"
-                    onClick={handleGenerateQR}
-                    disabled={connecting}
-                  >
-                    {connecting ? 'Generating...' : 'Generate QR Code'}
-                  </button>
-                </div>
-
-                <div className="connect-divider">
-                  <span>or</span>
-                </div>
-
-                <div className="connect-option">
-                  <h4>Option 2: Paste Bunker URI</h4>
-                  <p>Paste a bunker:// URI from your signer app.</p>
-                  <input
-                    type="text"
-                    className="form-input"
-                    placeholder="bunker://..."
-                    value={bunkerUri}
-                    onChange={e => setBunkerUri(e.target.value)}
-                    disabled={connecting}
-                  />
-                  <button
-                    className="btn btn-primary"
-                    onClick={handleBunkerLogin}
-                    disabled={connecting || !bunkerUri.trim()}
-                    style={{ marginTop: '8px' }}
-                  >
-                    {connecting ? 'Connecting...' : 'Connect'}
-                  </button>
-                </div>
-              </>
-            ) : (
-              <div className="connect-qr-container">
-                <p className="connect-description">
-                  Scan this QR code with your Nostr signer app (Amber, etc.)
-                </p>
-
-                <div className="qr-code-wrapper">
-                  <canvas ref={canvasRef} />
-                </div>
-
-                <p className="connect-waiting">
-                  Waiting for connection...
-                </p>
-
-                <div className="connect-qr-actions">
-                  <button className="btn btn-secondary" onClick={handleCopyUri}>
-                    Copy URI
-                  </button>
-                  <button className="btn btn-secondary" onClick={handleCancel}>
-                    Cancel
-                  </button>
-                </div>
-
-                <details className="connect-uri-details">
-                  <summary>Show connection URI</summary>
-                  <code className="connect-uri-code">{connectUri}</code>
-                </details>
+              <div className="connect-divider"><span>or</span></div>
+              <div className="connect-option">
+                <h4>Option 2: Paste Bunker URI</h4>
+                <p>Paste a bunker:// URI from your signer app.</p>
+                <input
+                  type="text"
+                  className="form-input"
+                  placeholder="bunker://..."
+                  value={bunkerUri}
+                  onChange={e => setBunkerUri(e.target.value)}
+                  disabled={connecting}
+                />
+                <button
+                  className="btn btn-primary"
+                  onClick={handleBunkerLogin}
+                  disabled={connecting || !bunkerUri.trim()}
+                  style={{ marginTop: '8px' }}
+                >
+                  {connecting ? 'Connecting...' : 'Connect'}
+                </button>
               </div>
-            )}
-          </div>
-        )}
+            </>
+          ) : (
+            <div className="connect-qr-container">
+              <p className="connect-description">
+                Scan this QR code with your Nostr signer app (Amber, etc.)
+              </p>
+              <div className="qr-code-wrapper">
+                <canvas ref={canvasRef} />
+              </div>
+              <p className="connect-waiting">Waiting for connection...</p>
+              <div className="connect-qr-actions">
+                <button className="btn btn-secondary" onClick={handleCopyUri}>Copy URI</button>
+                <button className="btn btn-secondary" onClick={handleCancel}>Cancel</button>
+              </div>
+              <details className="connect-uri-details">
+                <summary>Show connection URI</summary>
+                <code className="connect-uri-code">{connectUri}</code>
+              </details>
+            </div>
+          )}
+        </div>
+      )}
 
-        {error && (
-          <div className="connect-error">
-            {error}
-          </div>
-        )}
+      {error && <div className="connect-error">{error}</div>}
     </ModalWrapper>
   );
 }

--- a/src/store/nostrStore.tsx
+++ b/src/store/nostrStore.tsx
@@ -11,6 +11,7 @@ import {
 import {
   hasNip07Extension,
   initNip07Signer,
+  initManagedKeySigner,
   initNip46SignerFromBunker,
   waitForNip46Connection,
   reconnectNip46,
@@ -18,6 +19,7 @@ import {
   loadConnectionMethod,
   loadBunkerPointer,
 } from '../utils/nostrSigner';
+import { hexToBytes } from '@noble/hashes/utils';
 import { fetchNostrProfile } from '../utils/nostrSync';
 
 // Action types
@@ -26,10 +28,10 @@ type NostrAction =
   | { type: 'SET_ERROR'; payload: string | null }
   | { type: 'SET_HAS_EXTENSION'; payload: boolean }
   | { type: 'SET_CONNECTION_METHOD'; payload: 'nip07' | 'nip46' | null }
-  | { type: 'LOGIN_SUCCESS'; payload: { user: NostrUser; method: 'nip07' | 'nip46' } }
+  | { type: 'LOGIN_SUCCESS'; payload: { user: NostrUser; method: 'nip07' | 'nip46' | 'managed' } }
   | { type: 'UPDATE_PROFILE'; payload: { displayName?: string; picture?: string; nip05?: string } }
   | { type: 'LOGOUT' }
-  | { type: 'RESTORE_SESSION'; payload: { user: NostrUser; method: 'nip07' | 'nip46' } };
+  | { type: 'RESTORE_SESSION'; payload: { user: NostrUser; method: 'nip07' | 'nip46' | 'managed' } };
 
 // Initial state
 const initialState: NostrAuthState = {
@@ -97,6 +99,7 @@ interface NostrContextType {
   state: NostrAuthState;
   login: () => Promise<void>;
   loginWithNip46: (bunkerUri?: string, onUriGenerated?: (uri: string) => void) => Promise<void>;
+  loginWithGoogle: () => void;
   logout: () => void;
 }
 
@@ -125,84 +128,126 @@ export function NostrProvider({ children }: { children: ReactNode }) {
   // Check for extension and restore session on mount
   useEffect(() => {
     async function init() {
-      // Check for stored session
       const storedUser = loadStoredUser();
       const storedMethod = loadConnectionMethod();
 
-      // Check for NIP-07 extension
-      // Wait a bit for extension to inject
+      // Wait for NIP-07 extension to inject
       await new Promise(resolve => setTimeout(resolve, 500));
       const extensionAvailable = hasNip07Extension();
       dispatch({ type: 'SET_HAS_EXTENSION', payload: extensionAvailable });
 
-      // Try to restore session based on stored method
-      if (storedUser && storedMethod) {
-        if (storedMethod === 'nip46') {
-          // Try to reconnect NIP-46
-          const bunkerPointer = loadBunkerPointer();
-          if (bunkerPointer) {
-            try {
-              const pubkey = await reconnectNip46();
-              if (pubkey && pubkey === storedUser.pubkey) {
-                dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
-                refreshProfile(pubkey);
-                return;
-              }
-            } catch (e) {
-              console.error('[Nostr] Failed to reconnect NIP-46:', e);
-            }
-            // Reconnect failed — if credentials are still stored it was a timeout
-            // (reconnectNip46 only clears credentials for auth errors, not timeouts).
-            // Restore the UI session so the user appears logged in; read-only operations
-            // use the stored pubkey directly, and the signer will re-connect on the next
-            // signing operation via checkSignerConnection().
-            if (loadBunkerPointer()) {
-              dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
-              return;
-            }
-          }
-          // Credentials were cleared (auth error) — fully log out
-          clearStoredUser();
-          clearSigner();
-          dispatch({ type: 'SET_LOADING', payload: false });
-        } else if (storedMethod === 'nip07' && extensionAvailable) {
-          // Verify NIP-07 session
+      if (storedUser && storedMethod === 'nip46') {
+        const bunkerPointer = loadBunkerPointer();
+        if (bunkerPointer) {
           try {
-            const pubkey = await initNip07Signer();
-            if (pubkey === storedUser.pubkey) {
-              dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip07' } });
-
-              // Refresh profile in background
-              fetchNostrProfile(pubkey).then((profile) => {
-                if (profile) {
-                  dispatch({
-                    type: 'UPDATE_PROFILE',
-                    payload: {
-                      displayName: profile.display_name || profile.name,
-                      picture: profile.picture,
-                      nip05: profile.nip05
-                    }
-                  });
-                }
-              });
+            const pubkey = await reconnectNip46();
+            if (pubkey && pubkey === storedUser.pubkey) {
+              dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
+              refreshProfile(pubkey);
               return;
-            } else {
-              // Different account, clear stored session
-              clearStoredUser();
-              clearSigner();
             }
-          } catch {
-            // Extension refused or error, clear stored session
+          } catch (e) {
+            console.error('[Nostr] Failed to reconnect NIP-46:', e);
+          }
+          if (loadBunkerPointer()) {
+            dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip46' } });
+            return;
+          }
+        }
+        clearStoredUser();
+        clearSigner();
+        dispatch({ type: 'SET_LOADING', payload: false });
+      } else if (storedUser && storedMethod === 'nip07' && extensionAvailable) {
+        try {
+          const pubkey = await initNip07Signer();
+          if (pubkey === storedUser.pubkey) {
+            dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip07' } });
+            fetchNostrProfile(pubkey).then((profile) => {
+              if (profile) {
+                dispatch({
+                  type: 'UPDATE_PROFILE',
+                  payload: {
+                    displayName: profile.display_name || profile.name,
+                    picture: profile.picture,
+                    nip05: profile.nip05
+                  }
+                });
+              }
+            });
+            return;
+          } else {
             clearStoredUser();
             clearSigner();
           }
-          dispatch({ type: 'SET_LOADING', payload: false });
-        } else {
-          // No valid method to restore
+        } catch {
           clearStoredUser();
-          dispatch({ type: 'SET_LOADING', payload: false });
+          clearSigner();
         }
+        dispatch({ type: 'SET_LOADING', payload: false });
+      } else if (storedMethod === 'managed') {
+        // Restore managed (Google-authenticated) session
+        try {
+          const meRes = await fetch('/api/auth/me');
+          if (meRes.ok) {
+            const data = await meRes.json() as {
+              pubkey: string; npub: string; displayName?: string; picture?: string;
+            };
+            let skInitialized = false;
+            try {
+              const kpRes = await fetch('/api/auth/keypair');
+              if (kpRes.ok) {
+                const { sk: skHex } = await kpRes.json() as { sk: string };
+                initManagedKeySigner(hexToBytes(skHex));
+                skInitialized = true;
+              }
+            } catch { /* signer init failed — restore UI session without signing */ }
+            const user: NostrUser = {
+              pubkey: data.pubkey,
+              npub: data.npub,
+              displayName: data.displayName ?? storedUser?.displayName,
+              picture: data.picture ?? storedUser?.picture,
+            };
+            if (skInitialized) saveUser(user);
+            dispatch({ type: 'RESTORE_SESSION', payload: { user, method: 'managed' } });
+            return;
+          }
+        } catch { /* network error — fall through to clear */ }
+        // Cookie expired or network failure
+        clearStoredUser();
+        clearSigner();
+        dispatch({ type: 'SET_LOADING', payload: false });
       } else {
+        // Check if returning from Google OAuth (first-time login, no stored method yet)
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('auth') === 'success') {
+          window.history.replaceState({}, '', window.location.pathname);
+          try {
+            const meRes = await fetch('/api/auth/me');
+            if (meRes.ok) {
+              const data = await meRes.json() as {
+                pubkey: string; npub: string; displayName?: string; picture?: string;
+              };
+              let skInitialized = false;
+              try {
+                const kpRes = await fetch('/api/auth/keypair');
+                if (kpRes.ok) {
+                  const { sk: skHex } = await kpRes.json() as { sk: string };
+                  initManagedKeySigner(hexToBytes(skHex));
+                  skInitialized = true;
+                }
+              } catch { /* proceed without signer */ }
+              const user: NostrUser = {
+                pubkey: data.pubkey,
+                npub: data.npub,
+                displayName: data.displayName,
+                picture: data.picture,
+              };
+              if (skInitialized) saveUser(user);
+              dispatch({ type: 'LOGIN_SUCCESS', payload: { user, method: 'managed' } });
+              return;
+            }
+          } catch { /* fall through */ }
+        }
         dispatch({ type: 'SET_LOADING', payload: false });
       }
     }
@@ -283,6 +328,10 @@ export function NostrProvider({ children }: { children: ReactNode }) {
     }
   }, [refreshProfile]);
 
+  const loginWithGoogle = useCallback(() => {
+    window.location.href = '/api/auth/google-start';
+  }, []);
+
   // Logout function
   const logout = useCallback(() => {
     clearStoredUser();
@@ -291,7 +340,7 @@ export function NostrProvider({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <NostrContext.Provider value={{ state, login, loginWithNip46, logout }}>
+    <NostrContext.Provider value={{ state, login, loginWithNip46, loginWithGoogle, logout }}>
       {children}
     </NostrContext.Provider>
   );

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -53,7 +53,7 @@ export interface NostrAuthState {
   isLoading: boolean;
   error: string | null;
   hasExtension: boolean;
-  connectionMethod: 'nip07' | 'nip46' | null;
+  connectionMethod: 'nip07' | 'nip46' | 'managed' | null;
 }
 
 // Saved album info from Nostr

--- a/src/utils/nostrSigner.ts
+++ b/src/utils/nostrSigner.ts
@@ -1,7 +1,7 @@
 // Unified Nostr Signer - supports both NIP-07 (extension) and NIP-46 (remote signer)
 import { BunkerSigner, parseBunkerInput, createNostrConnectURI } from 'nostr-tools/nip46';
 import { SimplePool } from 'nostr-tools/pool';
-import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { generateSecretKey, getPublicKey, finalizeEvent } from 'nostr-tools/pure';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import type { EventTemplate, VerifiedEvent } from 'nostr-tools/pure';
 import type { BunkerPointer } from 'nostr-tools/nip46';
@@ -28,7 +28,7 @@ export interface NostrSigner {
 
 // Current active signer
 let currentSigner: NostrSigner | null = null;
-let currentMethod: 'nip07' | 'nip46' | null = null;
+let currentMethod: 'nip07' | 'nip46' | 'managed' | null = null;
 
 // NIP-07 Signer (browser extension)
 class Nip07Signer implements NostrSigner {
@@ -110,14 +110,14 @@ export function clearBunkerPointer(): void {
 }
 
 // Store connection method
-export function storeConnectionMethod(method: 'nip07' | 'nip46'): void {
+export function storeConnectionMethod(method: 'nip07' | 'nip46' | 'managed'): void {
   localStorage.setItem(CONNECTION_METHOD_KEY, method);
 }
 
 // Load connection method
-export function loadConnectionMethod(): 'nip07' | 'nip46' | null {
+export function loadConnectionMethod(): 'nip07' | 'nip46' | 'managed' | null {
   const stored = localStorage.getItem(CONNECTION_METHOD_KEY);
-  if (stored === 'nip07' || stored === 'nip46') return stored;
+  if (stored === 'nip07' || stored === 'nip46' || stored === 'managed') return stored;
   return null;
 }
 
@@ -331,6 +331,11 @@ export async function getPublicKeyWithTimeout(timeoutMs?: number): Promise<strin
 export async function checkSignerConnection(timeoutMs?: number): Promise<{ connected: boolean; error?: string }> {
   const method = currentMethod ?? loadConnectionMethod();
 
+  if (method === 'managed') {
+    if (hasSigner()) return { connected: true };
+    return { connected: false, error: 'Session expired. Please sign in again.' };
+  }
+
   if (method === 'nip46') {
     if (hasSigner()) {
       // Active signer — pool manages relay reconnects automatically.
@@ -383,8 +388,19 @@ export function hasSigner(): boolean {
 }
 
 // Get current connection method
-export function getConnectionMethod(): 'nip07' | 'nip46' | null {
+export function getConnectionMethod(): 'nip07' | 'nip46' | 'managed' | null {
   return currentMethod;
+}
+
+// Initialize a managed keypair signer (local signing, no external calls)
+export function initManagedKeySigner(sk: Uint8Array): void {
+  const pubkey = getPublicKey(sk);
+  currentSigner = {
+    getPublicKey: async () => pubkey,
+    signEvent: async (event) => finalizeEvent(event, sk),
+  };
+  currentMethod = 'managed';
+  storeConnectionMethod('managed');
 }
 
 // Clear signer (logout)
@@ -392,11 +408,15 @@ export function clearSigner(): void {
   if (currentSigner?.close) {
     currentSigner.close();
   }
+  const wasManaged = currentMethod === 'managed';
   currentSigner = null;
   currentMethod = null;
   clearBunkerPointer();
   clearClientSecretKey();
   clearConnectionMethod();
+  if (wasManaged) {
+    fetch('/api/auth/logout', { method: 'POST' }).catch(() => {});
+  }
 }
 
 // Check if NIP-07 extension is available


### PR DESCRIPTION
Users can now sign in with Google without needing any Nostr app:
- Google OAuth flow (google-start → google-callback) provisions a Nostr
  keypair on first login and stores it encrypted (AES-256-GCM, HKDF
  per-user key) in Vercel Blob
- Session managed via HttpOnly HS256 JWT cookie (30-day expiry)
- /api/auth/me, /api/auth/keypair, /api/auth/logout endpoints
- 'managed' connection method in nostrSigner uses finalizeEvent for
  local, instant signing — no extension or remote signer needed
- Session auto-restored on page reload via cookie + /api/auth/me check
- First-time login detected via ?auth=success URL param after OAuth callback
- Hamburger menu shows "My Nostr Keys" for managed users — they can
  reveal/copy their npub and nsec to import into Primal, Alby, etc.

Sign-in modal restructured to 4 tabs:
- Quick Sign In (Google, default)
- New to Nostr? (Primal 4-step walkthrough)
- Extension (NIP-07, unchanged)
- Remote Signer (NIP-46, unchanged)

Requires new env vars: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, AUTH_SECRET

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LVn8EYuFz77wBC1TM9bNEb