### PR TITLE
Use musicsideproject.com as canonical domain for all hosted feeds

### DIFF
--- a/api/_utils/feedUtils.ts
+++ b/api/_utils/feedUtils.ts
@@ -1,5 +1,4 @@
 // Shared API utilities for hosted feed endpoints
-import type { VercelRequest } from '@vercel/node';
 import { createHash, timingSafeEqual } from 'crypto';
 import { getAuthHeaders } from './podcastIndex.js';
 
@@ -172,16 +171,12 @@ export async function lookupPodcastIndexId(podcastGuid: string): Promise<number 
  * Get base URL from request headers
  * Falls back to canonical URL for localhost (PI can't reach local dev servers)
  */
-export function getBaseUrl(req: VercelRequest): string {
-  const host = req.headers['x-forwarded-host'] || req.headers.host || 'localhost';
-
-  // Use canonical URL for localhost since PI can't reach local dev servers
-  if (host.startsWith('localhost') || host.startsWith('127.0.0.1')) {
-    return process.env.CANONICAL_URL || 'https://msp.podtards.com';
-  }
-
-  const proto = req.headers['x-forwarded-proto'] || 'https';
-  return `${proto}://${host}`;
+export function getBaseUrl(): string {
+  // Always use the canonical domain for hosted feed URLs so every feed (album,
+  // video, publisher) is stable regardless of which alias/preview host served the
+  // request. msp.podtards.com is a legacy alias and must never appear in newly
+  // generated feed URLs.
+  return (process.env.CANONICAL_URL || 'https://musicsideproject.com').replace(/\/$/, '');
 }
 
 /**

--- a/api/example-feed.ts
+++ b/api/example-feed.ts
@@ -18,7 +18,7 @@ const EXAMPLE_FEED = `<?xml version="1.0" encoding="UTF-8"?>
         <description>
             This is an example feed created with MSP 2.0 (Music Side Project Studio). It demonstrates Podcasting 2.0 features including Value 4 Value Lightning payments, person credits, track-level value splits, and lyrics/transcript support. Use this as a reference when building your own music feeds.
         </description>
-        <link>https://msp.podtards.com</link>
+        <link>https://musicsideproject.com</link>
         <language>en</language>
         <generator>MSP 2.0 - Music Side Project Studio</generator>
         <pubDate>Sat, 01 Feb 2025 00:00:00 GMT</pubDate>
@@ -27,19 +27,19 @@ const EXAMPLE_FEED = `<?xml version="1.0" encoding="UTF-8"?>
         <itunes:category text="Music" />
         <itunes:keywords>example, demo, msp, podcasting2.0, value4value</itunes:keywords>
         <image>
-            <url>https://msp.podtards.com/msp-logo.png</url>
+            <url>https://musicsideproject.com/msp-logo.png</url>
             <title>MSP Example Album</title>
-            <link>https://msp.podtards.com</link>
+            <link>https://musicsideproject.com</link>
             <description>MSP Example Album artwork</description>
         </image>
-        <itunes:image href="https://msp.podtards.com/msp-logo.png" />
+        <itunes:image href="https://musicsideproject.com/msp-logo.png" />
         <podcast:medium>music</podcast:medium>
         <itunes:explicit>false</itunes:explicit>
         <itunes:owner>
             <itunes:name>MSP Demo Band</itunes:name>
-            <itunes:email>example@msp.podtards.com</itunes:email>
+            <itunes:email>example@musicsideproject.com</itunes:email>
         </itunes:owner>
-        <podcast:person href="https://msp.podtards.com" img="https://msp.podtards.com/msp-logo.png" group="music" role="band">MSP Demo Band</podcast:person>
+        <podcast:person href="https://musicsideproject.com" img="https://musicsideproject.com/msp-logo.png" group="music" role="band">MSP Demo Band</podcast:person>
         <podcast:person group="music" role="vocalist">Demo Singer</podcast:person>
         <podcast:person group="music" role="guitarist">Demo Guitarist</podcast:person>
         <podcast:person group="audio-post-production" role="composer">Demo Producer</podcast:person>
@@ -48,20 +48,20 @@ const EXAMPLE_FEED = `<?xml version="1.0" encoding="UTF-8"?>
             <podcast:valueRecipient name="Podcast Index" address="03ae9f91a0cb8ff43840e3c322c4c61f019d8c1c3cea15a25cfc425ac605e61a4a" split="1" type="node" />
             <podcast:valueRecipient name="MSP" address="podtards@strike.me" split="4" type="lnaddress" />
         </podcast:value>
-        <podcast:funding url="https://msp.podtards.com">Support MSP Development</podcast:funding>
+        <podcast:funding url="https://musicsideproject.com">Support MSP Development</podcast:funding>
         <item>
             <title>First Track</title>
             <description>The opening track of the album. Uses the album-level value block and person credits.</description>
             <pubDate>Sat, 01 Feb 2025 00:00:00 GMT</pubDate>
             <guid isPermaLink="false">a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d</guid>
-            <itunes:image href="https://msp.podtards.com/msp-logo.png" />
-            <podcast:images srcset="https://msp.podtards.com/msp-logo.png" />
+            <itunes:image href="https://musicsideproject.com/msp-logo.png" />
+            <podcast:images srcset="https://musicsideproject.com/msp-logo.png" />
             <enclosure url="https://example.com/audio/track01.mp3" length="5242880" type="audio/mpeg"/>
             <itunes:duration>3:45</itunes:duration>
             <podcast:season>1</podcast:season>
             <podcast:episode>1</podcast:episode>
             <itunes:explicit>false</itunes:explicit>
-            <podcast:person href="https://msp.podtards.com" img="https://msp.podtards.com/msp-logo.png" group="music" role="band">MSP Demo Band</podcast:person>
+            <podcast:person href="https://musicsideproject.com" img="https://musicsideproject.com/msp-logo.png" group="music" role="band">MSP Demo Band</podcast:person>
             <podcast:person group="music" role="vocalist">Demo Singer</podcast:person>
             <podcast:person group="music" role="guitarist">Demo Guitarist</podcast:person>
             <podcast:person group="audio-post-production" role="composer">Demo Producer</podcast:person>
@@ -77,14 +77,14 @@ const EXAMPLE_FEED = `<?xml version="1.0" encoding="UTF-8"?>
             <pubDate>Sat, 01 Feb 2025 00:01:00 GMT</pubDate>
             <guid isPermaLink="false">b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e</guid>
             <podcast:transcript url="https://example.com/lyrics/track02.srt" type="application/srt" />
-            <itunes:image href="https://msp.podtards.com/msp-logo.png" />
-            <podcast:images srcset="https://msp.podtards.com/msp-logo.png" />
+            <itunes:image href="https://musicsideproject.com/msp-logo.png" />
+            <podcast:images srcset="https://musicsideproject.com/msp-logo.png" />
             <enclosure url="https://example.com/audio/track02.mp3" length="6291456" type="audio/mpeg"/>
             <itunes:duration>4:32</itunes:duration>
             <podcast:season>1</podcast:season>
             <podcast:episode>2</podcast:episode>
             <itunes:explicit>false</itunes:explicit>
-            <podcast:person href="https://msp.podtards.com" img="https://msp.podtards.com/msp-logo.png" group="music" role="band">MSP Demo Band</podcast:person>
+            <podcast:person href="https://musicsideproject.com" img="https://musicsideproject.com/msp-logo.png" group="music" role="band">MSP Demo Band</podcast:person>
             <podcast:person group="music" role="vocalist">Demo Singer</podcast:person>
             <podcast:person group="music" role="guitarist">Demo Guitarist</podcast:person>
             <podcast:person group="audio-post-production" role="composer">Demo Producer</podcast:person>
@@ -99,8 +99,8 @@ const EXAMPLE_FEED = `<?xml version="1.0" encoding="UTF-8"?>
             <description>This track features a guest artist with their own value split. The track-level value block overrides the album default.</description>
             <pubDate>Sat, 01 Feb 2025 00:02:00 GMT</pubDate>
             <guid isPermaLink="false">c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f</guid>
-            <itunes:image href="https://msp.podtards.com/msp-logo.png" />
-            <podcast:images srcset="https://msp.podtards.com/msp-logo.png" />
+            <itunes:image href="https://musicsideproject.com/msp-logo.png" />
+            <podcast:images srcset="https://musicsideproject.com/msp-logo.png" />
             <enclosure url="https://example.com/audio/track03.mp3" length="7340032" type="audio/mpeg"/>
             <itunes:duration>5:18</itunes:duration>
             <podcast:season>1</podcast:season>

--- a/api/hosted/[feedId].ts
+++ b/api/hosted/[feedId].ts
@@ -138,9 +138,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         const blobResponse = await fetch(blob.url);
         const content = await blobResponse.text();
 
-        // Set cache and CORS headers
+        // Set cache and CORS headers. application/xml (not application/rss+xml)
+        // so browsers render the feed inline in a tab instead of downloading it;
+        // podcast apps / Podcast Index parse either content-type the same.
         res.setHeader('Cache-Control', 'public, max-age=300');
-        res.setHeader('Content-Type', 'application/rss+xml');
+        res.setHeader('Content-Type', 'application/xml; charset=utf-8');
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
 
@@ -302,7 +304,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
         // Notify Podcast Index and get PI ID (may update existing ID)
         // Skip PI/podping when in draft mode
-        const stableUrl = `${getBaseUrl(req)}/api/hosted/${feedId}.xml`;
+        const stableUrl = `${getBaseUrl()}/api/hosted/${feedId}.xml`;
         const medium = extractPodcastMedium(xml);
         let podcastIndexId: number | undefined;
         if (!effectiveIsDraft) {

--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -178,7 +178,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     });
 
     // Build stable URL
-    const stableUrl = `${getBaseUrl(req)}/api/hosted/${feedId}.xml`;
+    const stableUrl = `${getBaseUrl()}/api/hosted/${feedId}.xml`;
 
     // Extract podcast:medium from XML for podping broadcast (music/video/publisher)
     const medium = extractPodcastMedium(xml);

--- a/api/proxy-feed.ts
+++ b/api/proxy-feed.ts
@@ -77,6 +77,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   // Only allow fetching RSS/XML feeds from trusted podcast-host domains.
   const allowedDomains = [
+    'musicsideproject.com',
     'msp.podtards.com',
     'feeds.podcastindex.org',
     'anchor.fm',

--- a/src/utils/hostedFeed.ts
+++ b/src/utils/hostedFeed.ts
@@ -123,14 +123,13 @@ export async function deleteHostedFeed(
 }
 
 /**
- * Build the stable URL for a hosted feed
- * Uses VITE_CANONICAL_URL env var if set, otherwise falls back to current origin
+ * Build the stable URL for a hosted feed.
+ * Always uses the canonical domain (VITE_CANONICAL_URL, else musicsideproject.com)
+ * so feed URLs never bake in a preview/legacy host like msp.podtards.com.
  */
 export function buildHostedUrl(feedId: string): string {
-  const canonicalUrl = import.meta.env.VITE_CANONICAL_URL;
-  const origin = canonicalUrl
-    || (window.location.hostname === 'localhost' ? 'https://msp.podtards.com' : window.location.origin);
-  return `${origin}/api/hosted/${feedId}.xml`;
+  const base = (import.meta.env.VITE_CANONICAL_URL || 'https://musicsideproject.com').replace(/\/$/, '');
+  return `${base}/api/hosted/${feedId}.xml`;
 }
 
 /**

--- a/src/utils/publisherPublish.ts
+++ b/src/utils/publisherPublish.ts
@@ -64,6 +64,7 @@ const isMspHosted = (url: string): boolean => {
   if (!url) return false;
   return (
     url.includes('/api/hosted/') ||
+    url.includes('musicsideproject.com') ||
     url.includes('msp.podtards.com') ||
     url.includes('msp-2-0')
   );

--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -638,6 +638,7 @@ function parseTrack(node: unknown, trackNumber: number, albumValue: ValueBlock, 
 // Check if URL is an MSP-hosted feed
 const isMspUrl = (url: string): boolean => {
   return url.includes('/api/hosted/') ||
+    url.includes('musicsideproject.com') ||
     url.includes('msp.podtards.com') ||
     url.includes('msp-2-0');
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     proxy: {
       // Proxy API calls to production server during development
       '/api': {
-        target: 'https://msp.podtards.com',
+        target: 'https://musicsideproject.com',
         changeOrigin: true,
         secure: true
       }


### PR DESCRIPTION
Switches the canonical domain for hosted feed URLs from the legacy `msp.podtards.com` to `musicsideproject.com`, and serves feeds as inline-viewable XML.

## What changed
- **`getBaseUrl()`** always returns `CANONICAL_URL` (default `https://musicsideproject.com`), ignoring the request host — so album, video, and publisher feed URLs never bake in a legacy/preview host. Drops the now-unused `req` param + `VercelRequest` import.
- **`buildHostedUrl()`** uses `VITE_CANONICAL_URL` (default `https://musicsideproject.com`), no longer falling back to `window.origin`.
- Adds `musicsideproject.com` to MSP-hosted detection (`xmlParser`, `publisherPublish`) and the `proxy-feed` allowlist (legacy `msp.podtards.com` kept).
- Serves hosted feeds as `application/xml` so browsers render them **inline in a tab** instead of downloading.
- Updates the example feed + dev proxy target to the new domain.

## Notes
- Requires `CANONICAL_URL` and `VITE_CANONICAL_URL` = `https://musicsideproject.com` in Vercel (already set by owner). Code defaults to the new domain even if unset.
- `msp.podtards.com` remains a working alias. **Only newly generated URLs change** — feeds already submitted to Podcast Index keep their registered URL until re-saved.

## Verification
- `tsc --noEmit` clean; 134 tests pass.
- The pre-existing `nostrErr` ESLint warning at `publisherPublish.ts:546` is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)