### PR TITLE
301-redirect legacy msp.podtards.com hosted-feed URLs to canonical

### DIFF
--- a/api/hosted/[feedId].ts
+++ b/api/hosted/[feedId].ts
@@ -99,6 +99,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     switch (req.method) {
       case 'GET': {
+        // Legacy-host migration: feeds first hosted under msp.podtards.com were
+        // submitted to Podcast Index with that URL. Return a literal 301 to the
+        // canonical domain so apps/PI move the subscription. Exact-host match +
+        // canonical target means musicsideproject.com / preview hosts never loop.
+        const host = ((req.headers['x-forwarded-host'] || req.headers.host || '') as string).toLowerCase();
+        if (host === 'msp.podtards.com') {
+          res.setHeader('Location', `${getBaseUrl()}/api/hosted/${feedId}.xml`);
+          res.setHeader('Cache-Control', 'public, max-age=86400');
+          res.setHeader('Access-Control-Allow-Origin', '*');
+          return res.status(301).end();
+        }
+
         // List backups for this feed (admin only)
         if ('backups' in req.query) {
           if (!isAdmin) {


### PR DESCRIPTION
Feeds first hosted under `msp.podtards.com` were submitted to Podcast Index with that URL. Now that `musicsideproject.com` is canonical (PR #81), this makes the legacy feed URLs return a literal **301** so podcast apps / Podcast Index migrate subscribers to the canonical URL.

## Change
`api/hosted/[feedId].ts` — at the top of the GET handler, if the request `Host` is exactly `msp.podtards.com`, return `301` → `${getBaseUrl()}/api/hosted/<id>.xml` (canonical). 

- **Literal 301** (in code) because Vercel's `vercel.json` redirects emit 308, which Apple/PI don't treat the same for feed migration.
- **Loop-safe:** exact legacy-host match + canonical target → `musicsideproject.com` and `*.vercel.app` previews never match.
- **GET-only:** management verbs (PUT/DELETE/POST) come from the app on the canonical host, so they never hit the legacy domain.
- Scope is hosted feeds only — not a whole-domain redirect.

## Verification (after deploy)
- `curl -sS -D - -o /dev/null https://msp.podtards.com/api/hosted/<guid>.xml` → `301` + `location: https://musicsideproject.com/api/hosted/<guid>.xml`
- `curl -sS -o /dev/null -w '%{http_code}' https://musicsideproject.com/api/hosted/<guid>.xml` → `200` (no loop)
- `curl -sSL -o /dev/null -w '%{http_code}' https://msp.podtards.com/api/hosted/<guid>.xml` → `200` (follows to canonical)

`npm run build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)