### PR TITLE
Redirect legacy msp.podtards.com domain to musicsideproject.com

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,12 @@
 {
+  "redirects": [
+    {
+      "source": "/((?!api/).*)",
+      "has": [{ "type": "host", "value": "msp.podtards.com" }],
+      "destination": "https://musicsideproject.com/$1",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     { "source": "/admin", "destination": "/" }
   ]


### PR DESCRIPTION
Redirects the old `msp.podtards.com` domain to `musicsideproject.com` for the homepage and app routes, while preserving the literal 301 feed migration from PR #83.

## Change
`vercel.json` — a host-conditional permanent redirect:
- `source: /((?!api/).*)` — every path **except** `/api/`
- `has` host `msp.podtards.com` → `destination: https://musicsideproject.com/$1`, `permanent: true`

## Why this shape
- **Excludes `/api/`** so the hosted-feed paths keep their in-function literal **301** (podcast apps / Podcast Index need 301, but Vercel redirects emit 308). A Vercel *dashboard* domain-redirect would clobber that — hence doing it in code.
- **Host-scoped** to `msp.podtards.com`, so `musicsideproject.com` / `*.vercel.app` previews never match → no loop.
- `permanent` (308) is fine for browser/app navigation; only feeds need the literal 301.

## Verification (after deploy)
- `curl -sS -D - -o /dev/null https://msp.podtards.com/` → 308 + `location: https://musicsideproject.com/`
- `curl -sS -D - -o /dev/null https://msp.podtards.com/api/hosted/<guid>.xml` → still 301 (function, unchanged)
- `curl -sS -o /dev/null -w '%{http_code}' https://musicsideproject.com/` → 200 (no loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)