### PR TITLE
Fix slow profile name on sign-in: don't let a dead relay stall the fetch

### DIFF
--- a/src/utils/nostrRelay.ts
+++ b/src/utils/nostrRelay.ts
@@ -6,7 +6,7 @@ export const DEFAULT_RELAYS = [
   'wss://relay.damus.io',
   'wss://relay.primal.net',
   'wss://nos.lol',
-  'wss://relay.ditto.pub',
+  // 'wss://relay.ditto.pub' // Disabled — WebSocket unreachable in-browser (HTTP up, WSS fails)
   // 'wss://relay.nostr.band' // Temporarily disabled - unreachable
 ];
 

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -51,7 +51,10 @@ export async function fetchNostrProfile(
 
     const results = await Promise.allSettled(
       relays.map(async (relayUrl) => {
-        const ws = await connectRelay(relayUrl, 3000);
+        // Single attempt, no retries: this is a read gated by Promise.allSettled,
+        // so a dead relay's default 5× exponential-backoff retry (~30s) would
+        // stall the whole fetch — and the identity card — until it gives up.
+        const ws = await connectRelay(relayUrl, 3000, 1);
         try {
           const subId = Math.random().toString(36).substring(7);
           const filter = {

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -224,7 +224,10 @@ export async function loadAlbumsFromNostr(
     // Query each relay
     const results = await Promise.allSettled(
       relays.map(async (relayUrl) => {
-        const ws = await connectRelay(relayUrl);
+        // Single attempt, no retries: gated by Promise.allSettled, so a dead
+        // relay's default 5× exponential-backoff retry (~55s at 8s timeout)
+        // would stall the whole fan-out read until it gives up.
+        const ws = await connectRelay(relayUrl, 3000, 1);
         try {
           const subId = Math.random().toString(36).substring(7);
           const filter = {
@@ -302,7 +305,10 @@ export async function loadAlbumByDTag(
     // Query each relay
     const results = await Promise.allSettled(
       relays.map(async (relayUrl) => {
-        const ws = await connectRelay(relayUrl);
+        // Single attempt, no retries: gated by Promise.allSettled, so a dead
+        // relay's default 5× exponential-backoff retry (~55s at 8s timeout)
+        // would stall the whole fan-out read until it gives up.
+        const ws = await connectRelay(relayUrl, 3000, 1);
         try {
           const subId = Math.random().toString(36).substring(7);
           const filter = {
@@ -394,7 +400,10 @@ export async function fetchNostrMusicTracks(
     // Query each relay
     const results = await Promise.allSettled(
       relays.map(async (relayUrl) => {
-        const ws = await connectRelay(relayUrl);
+        // Single attempt, no retries: gated by Promise.allSettled, so a dead
+        // relay's default 5× exponential-backoff retry (~55s at 8s timeout)
+        // would stall the whole fan-out read until it gives up.
+        const ws = await connectRelay(relayUrl, 3000, 1);
         try {
           const subId = Math.random().toString(36).substring(7);
           const filter = {


### PR DESCRIPTION
fetchNostrProfile reads kind-0 across all relays via Promise.allSettled,
but connectRelay defaults to 5× exponential backoff (~30s) on a dead
relay — so one unreachable relay stalled the whole fetch and the identity
card name/pfp took ~30s to appear on login.

- nostrRelay.ts: disable the dead wss://relay.ditto.pub (HTTP up but its
  WebSocket is unreachable in-browser).
- nostrSync.ts: read with a single attempt (connectRelay(url, 3000, 1)) so
  a dead relay can't stall the allSettled and the identity card.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>