### PR TITLE
Restrict experimental features to local dev environment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,12 +220,16 @@ function AppContent() {
                   >
                     {theme === 'dark' ? '☀️' : '🌙'} Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
                   </button>
-                  <button
-                    className="dropdown-item"
-                    onClick={() => { toggleExperimental(); setShowDropdown(false); }}
-                  >
-                    🧪 {showExperimental ? 'Hide' : 'Show'} Experimental Features
-                  </button>
+                  {/* Local dev only — gated on import.meta.env.DEV so the experimental
+                      toggle is tree-shaken out of production builds */}
+                  {import.meta.env.DEV && (
+                    <button
+                      className="dropdown-item"
+                      onClick={() => { toggleExperimental(); setShowDropdown(false); }}
+                    >
+                      🧪 {showExperimental ? 'Hide' : 'Show'} Experimental Features
+                    </button>
+                  )}
                   <div className="dropdown-divider" />
                   {nostrState.isLoggedIn ? (
                     <button

--- a/src/store/experimentalStore.tsx
+++ b/src/store/experimentalStore.tsx
@@ -24,8 +24,13 @@ export function ExperimentalProvider({ children }: { children: ReactNode }) {
     setShowExperimental(prev => !prev);
   };
 
+  // Experimental features are only reachable in the local test environment.
+  // import.meta.env.DEV is true only under `npm run dev` and statically false in
+  // production builds, so the stored toggle can never expose them in production.
+  const effectiveShowExperimental = import.meta.env.DEV && showExperimental;
+
   return (
-    <ExperimentalContext.Provider value={{ showExperimental, toggleExperimental, setShowExperimental }}>
+    <ExperimentalContext.Provider value={{ showExperimental: effectiveShowExperimental, toggleExperimental, setShowExperimental }}>
       {children}
     </ExperimentalContext.Provider>
   );


### PR DESCRIPTION
Gate the experimental-features toggle and effective state on
import.meta.env.DEV so experimental Save/Import destinations are only
reachable under `npm run dev` and are tree-shaken out of production
builds. The localStorage toggle is preserved for the dev workflow but
can no longer expose experimental UI in production.

Co-Authored-By: Claude <noreply@anthropic.com>