### PR TITLE
Value block guardrails: block empty splits + pull LN wallet from Nostr

### DIFF
--- a/docs/superpowers/specs/2026-06-30-value-block-guardrails-design.md
+++ b/docs/superpowers/specs/2026-06-30-value-block-guardrails-design.md
@@ -1,0 +1,67 @@
+# Value Block Guardrails — Design
+
+**Date:** 2026-06-30
+**Branch:** `feature/value-block-guardrails`
+
+## Context
+
+Two related improvements to the Value Block (Lightning) editing experience:
+
+1. **Empty-split validation (the important one).** A user recently published a feed with a value recipient whose split % was left empty. Podcasting 2.0 splits are *proportional*, so an empty (→ 0) split means that recipient receives nothing and the remaining splits — the auto-added MSP 2.0 + Podcast Index community-support recipients — absorb 100% of the sats. The artist got nothing. MSP must not submit an incomplete feed to Podcast Index.
+
+2. **"Add my Lightning wallet (from Nostr)" button.** A Nostr-logged-in user's kind-0 profile already carries their lightning address (`lud16`). A one-click button in the Value Block should pull it in as a recipient so they don't have to retype it.
+
+## Scope decision
+
+The empty-split check hooks into the **existing `requiresValidation` gate** in `SaveModal.tsx` — the same gate the current "Missing required fields" errors use. This is deliberate: MSP only guarantees completeness for feeds it **generates and submits to Podcast Index**. If a user downloads an unfinished feed and self-hosts it, that is their responsibility, matching the existing behavior.
+
+- **Blocks on empty split:** the full existing `requiresValidation` set — Host on MSP, Publish to Nostr Music, Save RSS feed to Nostr (kind 30054), Blossom, nsite. (Save-to-Nostr doesn't hit PI, but it already runs the required-fields validation, so including it keeps behavior consistent and avoids saving a broken value block anywhere.)
+- **Exempt (unchanged):** Save to Local Storage, Download XML, Copy to Clipboard, Submit to PodcastIndex (URL-only — the bytes live elsewhere).
+
+## Feature 1 — Empty-split validation
+
+### Rule
+Every value recipient that is present in a value block must have `split > 0`. Empty/`0`/negative is invalid. Community-support recipients already carry `split: 1`, so they always pass.
+
+### Coverage (every value block)
+- Album/video feed level: `album.value.recipients`
+- Per track: `track.value.recipients` (each track)
+- Publisher: `publisherFeed.value.recipients`
+
+### Implementation
+- New pure helper `getValueRecipientErrors(recipients, label)` in `src/utils/valueValidation.ts`: returns an array of human-readable error strings for any recipient with `split <= 0` (or non-finite). Label is a prefix like `"Value recipient"` or `"Track 2 value recipient"`.
+- In `SaveModal.tsx`, inside the existing `if (requiresValidation) { ... }` block, call the helper for the album/publisher feed-level recipients and (for album/video) each track's recipients, pushing any errors into the same `errors` array that already produces the `"Missing required fields: ..."` message. No new save-blocking path is introduced.
+- Error text names the offender, e.g. `Value recipient "Alice" — split % is required` / `Track 2 value recipient "Alice" — split % is required`. A recipient with no name falls back to its address, then to its index.
+
+### Tests
+`src/utils/valueValidation.test.ts` (Vitest): empty split flagged, `0` flagged, negative flagged, valid `>0` passes, community-support (`split:1`) passes, label prefix + name/address/index fallbacks in the message, multiple offenders each reported.
+
+## Feature 2 — "Add my Lightning wallet (from Nostr)" button
+
+### Data plumbing
+- Extend `NostrProfile` (`src/utils/nostrSync.ts`) with `lud16?: string` and `lud06?: string`. `fetchNostrProfile` already `JSON.parse`s the full kind-0 content, so these fields simply surface data already fetched.
+- Extend `NostrUser` (`src/types/nostr.ts`) with `lud16?: string`, and populate it from `profile.lud16` in the `UPDATE_PROFILE` dispatch in `src/store/nostrStore.tsx` (both the login and the restore-session refresh paths). This caches the address so the button is instant and can be shown conditionally with no extra relay round-trip.
+
+### UI (`src/components/RecipientsList.tsx`)
+- `RecipientsList` gains access to Nostr state via `useNostr()`.
+- A button **"⚡ Add my Lightning wallet"** rendered near `AddRecipientSelect`, shown only when: `nostrState.isLoggedIn && nostrState.user?.lud16` **and** that address is not already among `recipients` (duplicate guard — hidden once added).
+- On click, `onAdd` a recipient:
+  - `address`: `user.lud16`
+  - `type`: `detectAddressType(lud16)` (an `@` → `'lnaddress'`)
+  - `name`: `user.displayName` (falls back to empty)
+  - `split`: **remaining unallocated** = `max(0, 100 − sum(existing splits))`
+- Reuses the existing `onAdd` → `ADD_RECIPIENT` flow, so the feed's community-support auto-append logic behaves exactly as for a manually typed address.
+
+### Scope limits (intentional)
+- **`lud16` only.** A raw `lud06` (LNURL) is not a valid Podcasting 2.0 value-recipient address, so a profile with only `lud06` shows no button. Can revisit later.
+- No relay re-fetch on click — uses the login-time cached `lud16`.
+
+## Out of scope
+- Splits summing to exactly 100 (Podcasting 2.0 splits are proportional; not required).
+- Inline per-field error styling in the editor (the save-time block is sufficient for the reported problem; can add later).
+- Resolving `lud06`/LNURL into an address.
+
+## Verification
+- `npm run test` — the new `valueValidation.test.ts` passes.
+- `npm run build` (tsc -b + vite) — the authoritative typecheck per CLAUDE.md.
+- Manual: (a) leave a recipient's split empty → Host on MSP is blocked with a clear error; Download XML still works. (b) Log in with a Nostr profile that has a `lud16` → the "Add my Lightning wallet" button appears, adds the address with the remaining split, and disappears once added.

--- a/docs/superpowers/specs/2026-06-30-value-block-guardrails-design.md
+++ b/docs/superpowers/specs/2026-06-30-value-block-guardrails-design.md
@@ -44,13 +44,12 @@ Every value recipient that is present in a value block must have `split > 0`. Em
 
 ### UI (`src/components/RecipientsList.tsx`)
 - `RecipientsList` gains access to Nostr state via `useNostr()`.
-- A button **"⚡ Add my Lightning wallet"** rendered near `AddRecipientSelect`, shown only when: `nostrState.isLoggedIn && nostrState.user?.lud16` **and** that address is not already among `recipients` (duplicate guard — hidden once added).
-- On click, `onAdd` a recipient:
+- **Inline autofill, not a row-adder.** Each non-support recipient row shows a small **"⚡ Use my Lightning wallet"** link under its Address input, shown only when `nostrState.isLoggedIn && nostrState.user?.lud16` **and** that row's address isn't already the wallet. It's positioned by the address field because it's purely a shortcut for *entering the address* — avoiding typos that would silently misroute sats.
+- On click, `onUpdate` that row with:
   - `address`: `user.lud16`
   - `type`: `detectAddressType(lud16)` (an `@` → `'lnaddress'`)
-  - `name`: `user.displayName` (falls back to empty)
-  - `split`: **remaining unallocated** = `max(0, 100 − sum(existing splits))`
-- Reuses the existing `onAdd` → `ADD_RECIPIENT` flow, so the feed's community-support auto-append logic behaves exactly as for a manually typed address.
+  - `name`: keeps the row's name, or fills `user.displayName` if blank
+- **Deliberately does not set the split.** The user chooses their own split; a fixed value (e.g. "remaining" = 100 on an empty block) would be a surprising guess. If they leave it blank, the empty-split guardrail (Feature 1) catches it before a PI submission.
 
 ### Scope limits (intentional)
 - **`lud16` only.** A raw `lud06` (LNURL) is not a valid Podcasting 2.0 value-recipient address, so a profile with only `lud06` shows no button. Can revisit later.
@@ -64,4 +63,4 @@ Every value recipient that is present in a value block must have `split > 0`. Em
 ## Verification
 - `npm run test` — the new `valueValidation.test.ts` passes.
 - `npm run build` (tsc -b + vite) — the authoritative typecheck per CLAUDE.md.
-- Manual: (a) leave a recipient's split empty → Host on MSP is blocked with a clear error; Download XML still works. (b) Log in with a Nostr profile that has a `lud16` → the "Add my Lightning wallet" button appears, adds the address with the remaining split, and disappears once added.
+- Manual: (a) leave a recipient's split empty → Host on MSP is blocked with a clear error; Download XML still works. (b) Log in with a Nostr profile that has a `lud16` → the inline "⚡ Use my Lightning wallet" link appears under a row's Address field, fills the address (and name if blank) on click without touching the split, and disappears once that row holds the wallet.

--- a/src/components/RecipientsList.tsx
+++ b/src/components/RecipientsList.tsx
@@ -2,6 +2,7 @@ import type { ValueRecipient } from '../types/feed';
 import { createSupportRecipients, isCommunitySupport } from '../types/feed';
 import { FIELD_INFO } from '../data/fieldInfo';
 import { detectAddressType } from '../utils/addressUtils';
+import { useNostr } from '../store/nostrStore';
 import { InfoIcon } from './InfoIcon';
 import { AddRecipientSelect } from './AddRecipientSelect';
 
@@ -13,6 +14,23 @@ interface RecipientsListProps {
 }
 
 export function RecipientsList({ recipients, onUpdate, onRemove, onAdd }: RecipientsListProps) {
+  const { state: nostrState } = useNostr();
+
+  // Lightning address from the logged-in user's Nostr profile (kind-0 lud16), if any.
+  const nostrLud16 = nostrState.isLoggedIn ? nostrState.user?.lud16?.trim() : undefined;
+
+  // Fill a recipient row's address with the user's Nostr lightning address — a shortcut
+  // so they don't have to type it out. Also fills the name if it's still blank.
+  const fillWithNostrWallet = (recipient: ValueRecipient, index: number) => {
+    if (!nostrLud16) return;
+    onUpdate(index, {
+      ...recipient,
+      address: nostrLud16,
+      type: detectAddressType(nostrLud16),
+      name: recipient.name?.trim() || nostrState.user?.displayName || ''
+    });
+  };
+
   // Separate user recipients from platform recipients, preserving original indices
   const userRecipients: { recipient: ValueRecipient; originalIndex: number }[] = [];
   const platformRecipients: { recipient: ValueRecipient; originalIndex: number }[] = [];
@@ -56,6 +74,25 @@ export function RecipientsList({ recipients, onUpdate, onRemove, onAdd }: Recipi
               readOnly={isSupport}
               style={isSupport ? { opacity: 0.7, cursor: 'default' } : undefined}
             />
+            {!isSupport && nostrLud16 && recipient.address.trim().toLowerCase() !== nostrLud16.toLowerCase() && (
+              <button
+                type="button"
+                onClick={() => fillWithNostrWallet(recipient, originalIndex)}
+                title={`Use ${nostrLud16} from your Nostr profile`}
+                style={{
+                  marginTop: '6px',
+                  background: 'none',
+                  border: 'none',
+                  color: 'var(--accent-color, #f59e0b)',
+                  fontSize: '12px',
+                  cursor: 'pointer',
+                  padding: 0,
+                  textDecoration: 'underline'
+                }}
+              >
+                ⚡ Use my Lightning wallet
+              </button>
+            )}
           </div>
           <div className="form-group">
             <label className="form-label">Split %<InfoIcon text={FIELD_INFO.recipientSplit} /></label>

--- a/src/components/RecipientsList.tsx
+++ b/src/components/RecipientsList.tsx
@@ -60,7 +60,37 @@ export function RecipientsList({ recipients, onUpdate, onRemove, onAdd }: Recipi
             />
           </div>
           <div className="form-group">
-            <label className="form-label">Address{!isSupport && <InfoIcon text={FIELD_INFO.recipientAddress} />}</label>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
+              <label className="form-label" style={{ marginBottom: 0 }}>Address{!isSupport && <InfoIcon text={FIELD_INFO.recipientAddress} />}</label>
+              {!isSupport && nostrLud16 && (
+                recipient.address.trim().toLowerCase() === nostrLud16.toLowerCase() ? (
+                  <span
+                    title="This is your Nostr profile's lightning address"
+                    style={{ fontSize: '12px', color: 'var(--success, #10b981)', whiteSpace: 'nowrap' }}
+                  >
+                    ✓ Your Nostr wallet
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => fillWithNostrWallet(recipient, originalIndex)}
+                    title={`Fill in ${nostrLud16} from your Nostr profile`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: 'var(--accent-color, #f59e0b)',
+                      fontSize: '12px',
+                      cursor: 'pointer',
+                      padding: 0,
+                      whiteSpace: 'nowrap',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    ⚡ Use my Nostr wallet
+                  </button>
+                )
+              )}
+            </div>
             <input
               type="text"
               className="form-input"
@@ -74,25 +104,6 @@ export function RecipientsList({ recipients, onUpdate, onRemove, onAdd }: Recipi
               readOnly={isSupport}
               style={isSupport ? { opacity: 0.7, cursor: 'default' } : undefined}
             />
-            {!isSupport && nostrLud16 && recipient.address.trim().toLowerCase() !== nostrLud16.toLowerCase() && (
-              <button
-                type="button"
-                onClick={() => fillWithNostrWallet(recipient, originalIndex)}
-                title={`Use ${nostrLud16} from your Nostr profile`}
-                style={{
-                  marginTop: '6px',
-                  background: 'none',
-                  border: 'none',
-                  color: 'var(--accent-color, #f59e0b)',
-                  fontSize: '12px',
-                  cursor: 'pointer',
-                  padding: 0,
-                  textDecoration: 'underline'
-                }}
-              >
-                ⚡ Use my Lightning wallet
-              </button>
-            )}
           </div>
           <div className="form-group">
             <label className="form-label">Split %<InfoIcon text={FIELD_INFO.recipientSplit} /></label>

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -26,6 +26,7 @@ import { useNostr } from '../../store/nostrStore';
 import { useExperimental } from '../../store/experimentalStore';
 import { checkSignerConnection } from '../../utils/nostrSigner';
 import { getFeedUrlError } from '../../utils/urlValidation';
+import { getValueRecipientErrors } from '../../utils/valueValidation';
 import { ModalWrapper } from './ModalWrapper';
 
 const DEFAULT_BLOSSOM_SERVER = 'https://blossom.primal.net/';
@@ -357,6 +358,8 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
         if (!publisherFeed.title?.trim()) errors.push('Catalog Title');
         if (!publisherFeed.description?.trim()) errors.push('Description');
         if (!publisherFeed.podcastGuid?.trim()) errors.push('Publisher GUID');
+        // Every value recipient needs a non-zero split or its sats silently redistribute.
+        errors.push(...getValueRecipientErrors(publisherFeed.value?.recipients, 'Value recipient'));
       } else {
         // Album validation
         // Nostr Music (kind 36787 / 34139) doesn't carry description, file size,
@@ -371,6 +374,9 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
         if (!album.language?.trim()) errors.push('Language');
         if (!album.podcastGuid?.trim()) errors.push('Podcast GUID');
 
+        // Feed-level value recipients: every one needs a non-zero split.
+        errors.push(...getValueRecipientErrors(album.value?.recipients, 'Value recipient'));
+
         const itemLabel = isVideoMode ? 'Video' : 'Track';
         const urlLabel = isVideoMode ? 'Video URL' : 'MP3 URL';
         album.tracks.forEach((track, i) => {
@@ -378,6 +384,8 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
           if (!isNostrMusicMode && !track.duration?.trim()) errors.push(`${itemLabel} ${i + 1} Duration`);
           if (!track.enclosureUrl?.trim()) errors.push(`${itemLabel} ${i + 1} ${urlLabel}`);
           if (!isNostrMusicMode && !track.enclosureLength?.trim()) errors.push(`${itemLabel} ${i + 1} File Size`);
+          // Per-track value recipients (optional block, but if present each needs a split).
+          errors.push(...getValueRecipientErrors(track.value?.recipients, `${itemLabel} ${i + 1} value recipient`));
         });
       }
 

--- a/src/store/nostrStore.tsx
+++ b/src/store/nostrStore.tsx
@@ -174,20 +174,8 @@ export function NostrProvider({ children }: { children: ReactNode }) {
             if (pubkey === storedUser.pubkey) {
               dispatch({ type: 'RESTORE_SESSION', payload: { user: storedUser, method: 'nip07' } });
 
-              // Refresh profile in background
-              fetchNostrProfile(pubkey).then((profile) => {
-                if (profile) {
-                  dispatch({
-                    type: 'UPDATE_PROFILE',
-                    payload: {
-                      displayName: profile.display_name || profile.name,
-                      picture: profile.picture,
-                      nip05: profile.nip05,
-                      lud16: profile.lud16
-                    }
-                  });
-                }
-              });
+              // Refresh profile in background (single source of the profile→user mapping)
+              refreshProfile(pubkey);
               return;
             } else {
               // Different account, clear stored session

--- a/src/store/nostrStore.tsx
+++ b/src/store/nostrStore.tsx
@@ -27,7 +27,7 @@ type NostrAction =
   | { type: 'SET_HAS_EXTENSION'; payload: boolean }
   | { type: 'SET_CONNECTION_METHOD'; payload: 'nip07' | 'nip46' | null }
   | { type: 'LOGIN_SUCCESS'; payload: { user: NostrUser; method: 'nip07' | 'nip46' } }
-  | { type: 'UPDATE_PROFILE'; payload: { displayName?: string; picture?: string; nip05?: string } }
+  | { type: 'UPDATE_PROFILE'; payload: { displayName?: string; picture?: string; nip05?: string; lud16?: string } }
   | { type: 'LOGOUT' }
   | { type: 'RESTORE_SESSION'; payload: { user: NostrUser; method: 'nip07' | 'nip46' } };
 
@@ -67,7 +67,8 @@ function nostrReducer(state: NostrAuthState, action: NostrAction): NostrAuthStat
         ...state.user,
         displayName: action.payload.displayName || state.user.displayName,
         picture: action.payload.picture || state.user.picture,
-        nip05: action.payload.nip05 || state.user.nip05
+        nip05: action.payload.nip05 || state.user.nip05,
+        lud16: action.payload.lud16 || state.user.lud16
       };
       saveUser(updatedUser);
       return { ...state, user: updatedUser };
@@ -115,7 +116,8 @@ export function NostrProvider({ children }: { children: ReactNode }) {
           payload: {
             displayName: profile.display_name || profile.name,
             picture: profile.picture,
-            nip05: profile.nip05
+            nip05: profile.nip05,
+            lud16: profile.lud16
           }
         });
       }
@@ -180,7 +182,8 @@ export function NostrProvider({ children }: { children: ReactNode }) {
                     payload: {
                       displayName: profile.display_name || profile.name,
                       picture: profile.picture,
-                      nip05: profile.nip05
+                      nip05: profile.nip05,
+                      lud16: profile.lud16
                     }
                   });
                 }

--- a/src/types/nostr.ts
+++ b/src/types/nostr.ts
@@ -44,6 +44,7 @@ export interface NostrUser {
   displayName?: string; // from profile metadata (kind 0)
   picture?: string;     // profile picture URL
   nip05?: string;       // NIP-05 identifier
+  lud16?: string;       // Lightning address (user@domain) from profile metadata
 }
 
 // Auth state

--- a/src/utils/nostrSync.ts
+++ b/src/utils/nostrSync.ts
@@ -39,6 +39,8 @@ export interface NostrProfile {
   picture?: string;
   nip05?: string;
   about?: string;
+  lud16?: string; // Lightning address (user@domain)
+  lud06?: string; // LNURL
 }
 
 // Fetch user profile (kind 0) from relays

--- a/src/utils/valueValidation.test.ts
+++ b/src/utils/valueValidation.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { getValueRecipientErrors } from './valueValidation';
+import type { ValueRecipient } from '../types/feed';
+
+function rec(partial: Partial<ValueRecipient>): ValueRecipient {
+  return { name: '', address: '', split: 0, type: 'lnaddress', ...partial };
+}
+
+describe('getValueRecipientErrors', () => {
+  it('returns no errors for an empty or undefined list', () => {
+    expect(getValueRecipientErrors([], 'Value recipient')).toEqual([]);
+    expect(getValueRecipientErrors(undefined, 'Value recipient')).toEqual([]);
+  });
+
+  it('flags a recipient with a 0 split', () => {
+    const errors = getValueRecipientErrors([rec({ name: 'Alice', address: 'alice@x.com', split: 0 })], 'Value recipient');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Alice');
+    expect(errors[0]).toContain('split');
+  });
+
+  it('flags an empty/NaN split', () => {
+    const errors = getValueRecipientErrors([rec({ name: 'Bob', split: NaN })], 'Value recipient');
+    expect(errors).toHaveLength(1);
+  });
+
+  it('flags a negative split', () => {
+    expect(getValueRecipientErrors([rec({ name: 'Neg', split: -5 })], 'Value recipient')).toHaveLength(1);
+  });
+
+  it('passes a recipient with a positive split', () => {
+    expect(getValueRecipientErrors([rec({ name: 'Alice', split: 94 })], 'Value recipient')).toEqual([]);
+  });
+
+  it('passes community-support recipients (split 1)', () => {
+    const support = [
+      rec({ name: 'MSP 2.0', address: 'chadf@getalby.com', split: 1 }),
+      rec({ name: 'Podcastindex.org', address: 'podcastindex@getalby.com', split: 1 })
+    ];
+    expect(getValueRecipientErrors(support, 'Value recipient')).toEqual([]);
+  });
+
+  it('uses the label prefix in the message', () => {
+    const errors = getValueRecipientErrors([rec({ name: 'Alice', split: 0 })], 'Track 2 value recipient');
+    expect(errors[0]).toContain('Track 2 value recipient');
+  });
+
+  it('falls back to address, then to index, when the name is empty', () => {
+    const byAddress = getValueRecipientErrors([rec({ name: '', address: 'zap@me.com', split: 0 })], 'Value recipient');
+    expect(byAddress[0]).toContain('zap@me.com');
+    const byIndex = getValueRecipientErrors([rec({ name: '', address: '', split: 0 })], 'Value recipient');
+    expect(byIndex[0]).toContain('#1');
+  });
+
+  it('reports every offender', () => {
+    const errors = getValueRecipientErrors([
+      rec({ name: 'Good', split: 50 }),
+      rec({ name: 'Bad1', split: 0 }),
+      rec({ name: 'Bad2', split: NaN })
+    ], 'Value recipient');
+    expect(errors).toHaveLength(2);
+  });
+});

--- a/src/utils/valueValidation.ts
+++ b/src/utils/valueValidation.ts
@@ -1,0 +1,29 @@
+import type { ValueRecipient } from '../types/feed';
+
+/**
+ * Validate that every value recipient has a usable split.
+ *
+ * Podcasting 2.0 splits are proportional, so a recipient left at 0 (or empty → NaN)
+ * receives nothing and the remaining splits absorb all the sats — a silent way for an
+ * artist's share to end up going entirely to the community-support recipients. This
+ * returns a human-readable error for each offending recipient so the Save flow can block
+ * submitting an incomplete feed to Podcast Index.
+ *
+ * @param recipients the value block's recipients (undefined/empty → no errors)
+ * @param label prefix for the message, e.g. "Value recipient" or "Track 2 value recipient"
+ */
+export function getValueRecipientErrors(
+  recipients: ValueRecipient[] | undefined,
+  label: string
+): string[] {
+  if (!recipients || recipients.length === 0) return [];
+
+  const errors: string[] = [];
+  recipients.forEach((recipient, index) => {
+    if (!Number.isFinite(recipient.split) || recipient.split <= 0) {
+      const who = recipient.name?.trim() || recipient.address?.trim() || `#${index + 1}`;
+      errors.push(`${label} "${who}" needs a split %`);
+    }
+  });
+  return errors;
+}


### PR DESCRIPTION
Two Value-block (Lightning) improvements. **Safe to merge now — no infra required.**

## 1. Block save on empty value-split (bug fix)
A recipient left with an empty/0 split silently redistributes its sats to the remaining splits — in practice the auto-added MSP 2.0 + Podcast Index community-support recipients — so an artist who forgot their split got nothing. This blocks it at save.

- New `getValueRecipientErrors()` helper (`valueValidation.ts`), flags any recipient with an empty/0/negative split. **9 unit tests.**
- Hooked into the **existing `requiresValidation` gate** in SaveModal, so it blocks exactly the feed-generating / PI-submitting paths (Host on MSP, Nostr Music, Save-to-Nostr, Blossom, nsite) and leaves Download XML / Copy / Local / Submit-to-PI untouched. Covers feed-level, per-track, and publisher value blocks.

## 2. "⚡ Use my Nostr wallet" autofill
Inline link on each recipient's Address field that fills the logged-in user's profile lightning address (`lud16`) — no typing, no typos that would misroute sats. Fills address + name only (never the split). Shows a muted "✓ Your Nostr wallet" once a row already holds it.

## Refactor included
- `nostrStore.tsx`: the session-restore profile fetch was a verbatim copy of `refreshProfile()` — deduped to a single source.

## Verification
`npm run build` clean, **143 tests pass**, no new lint errors. Design spec: `docs/superpowers/specs/2026-06-30-value-block-guardrails-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)