### PR TITLE
Email magic-link auth for MSP-hosted feeds (⚠️ needs Resend + DNS before merge)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,15 @@ A `.env` file is required with the following variables:
 - `VITE_CANONICAL_URL` - Canonical URL for the application
 - `PODPING_ENDPOINT_URL` - Full URL to MSP's self-hosted podping-hivepinger Railway service, trailing slash (optional; podping notifications are skipped when unset)
 - `PODPING_BEARER_TOKEN` - Bearer token shared with the Railway service (optional; podping notifications are skipped when unset)
+- `RESEND_API_KEY` - Resend API key for sending email magic links (optional; email auth no-ops when unset, gated by `isEmailConfigured()` in `api/_utils/sendEmail.ts`)
+- `MSP_EMAIL_FROM` - Verified Resend sender address, e.g. `noreply@musicsideproject.com` (optional; required alongside `RESEND_API_KEY` for email auth)
+- `MSP_SESSION_SECRET` - HMAC secret signing email session JWTs (server-only). Rotating it invalidates all email sessions
+- `MSP_EMAIL_HASH_KEY` - HMAC key for `ownerEmailHash`. Kept separate from `MSP_SESSION_SECRET` so sessions can rotate without orphaning feed ownership. **Rotating this breaks email→feed ownership matching**
+- `MSP_MAGIC_LINK_TTL_MIN` - Magic-link lifetime in minutes (optional; default 15)
 
 No `.env.example` exists - request credentials from the team.
+
+**Email auth DNS** (for magic-link deliverability on `musicsideproject.com`): add the SPF (`include:_spf.resend.com`, merged into a single SPF TXT), Resend DKIM records, and a DMARC TXT (`p=none` to start) — verify the domain in the Resend dashboard. MX is **not** required (send-only).
 
 ### Getting Started
 ```bash
@@ -239,6 +246,18 @@ The modern singular `<podcast:image>` tag (supersedes the deprecated plural `<po
 - Parser (`xmlParser.ts`): `stripOp3Prefix()` detects and removes OP3 prefix on import, sets `album.op3 = true`
 - Stats link shown in Save modal (hosted section) — OP3 needs a few days of downloads before stats page is available
 - Tests in `xmlGenerator.test.ts` and `xmlParser.test.ts` cover prefix generation, stripping, and round-trip
+
+### Email Magic-Link Feed Ownership
+A non-Nostr, password-free way to **own and recover MSP-hosted feeds** (for self-hosting musicians who avoid Nostr/Google — e.g. Blossom/nostr.build users whose media is content-addressed so MSP hosts their static feed XML). It's a **third owner type alongside the edit token and Nostr** — every hosted feed write tries token → Nostr owner → email owner.
+- **Auth model**: passwordless magic link. The raw email is **never persisted** — only `emailHash` (keyed HMAC via `MSP_EMAIL_HASH_KEY`) is stored. Sessions are stateless HS256 JWTs (`MSP_SESSION_SECRET`), sent as `X-Email-Session: Bearer <jwt>`. Helpers in `api/_utils/emailAuth.ts` (mirrors `adminAuth.ts`'s `{valid, ...}` shape).
+- **Blob storage** (`api/_utils/accountStore.ts`): `@vercel/blob` has no private mode, so both namespaces are public blobs with **unguessable paths** — single-use link records at `accounts/links/<sha256(token)>.json` (deleted on redeem) and the per-account feed index at `accounts/index/<emailHash>.json` (contents are just public feed GUIDs). External callers can't `list()` or guess the store subdomain + high-entropy path.
+- **Endpoints**: `api/auth/magic-link.ts` (POST, rate-limited per IP+emailHash, enumeration-safe `{sent:true}`, claim requires proving the edit token first), `api/auth/verify.ts` (POST, single-use redeem → session; a `claim` link also stamps `ownerEmailHash` onto the feed + indexes it), `api/account/feeds.ts` (GET, lists the account's feeds via the shared `feedHydrate.ts` helper).
+- **Hosted writes** (`api/hosted/[feedId].ts`): `FeedMetadata.ownerEmailHash`/`emailLinkedAt`; PUT/DELETE accept an email-session owner (DELETE previously had no owner path at all — fixed for both Nostr and email); PATCH generalized to link either a Nostr or email identity (`emailSessionOwns()` helper).
+- **Email send** (`api/_utils/sendEmail.ts`): Resend, send-only, no-ops via `isEmailConfigured()` when unconfigured (mirrors `isPodpingConfigured()`).
+- **Frontend**: `EmailLoginModal.tsx` (login + claim), `VerifyMagicLink.tsx` at route `/auth/verify`, `emailSession.ts` (request/verify + `withEmailAuth()`), `emailSessionStorage` in `storage.ts`. `hostedFeed.ts` has `*WithEmail` variants + `linkEmailToFeed` (analog of `linkNostrToFeed`). SaveModal prefers Nostr → email → token and drops the "save your token" gate for email users; ImportModal "My Hosted Feeds" works for email accounts. **This is a production feature — not gated behind the experimental flag.**
+- **Setup prerequisites** (must be done before it works end-to-end): a Resend account + verified domain, the env vars above, and the SPF/DKIM/DMARC DNS records. Until then it cleanly no-ops.
+- **Known follow-ups** (not yet done): the publisher `CatalogFeedsSection.tsx` "Browse My MSP Feeds" and the `/admin` `AdminPage.tsx` dashboard are still Nostr-only (not generalized to email); NIP-98 events still aren't bound to URL/method (pre-existing).
+- Tests: `api/_utils/emailAuth.test.ts`, `sendEmail.test.ts`, `accountStore.test.ts`, `api/auth/*.test.ts`, `api/account/feeds.test.ts`, `api/hosted/feedId-email-auth.test.ts`.
 
 ### Nostr Integration
 - NIP-07 browser extension support for signing

--- a/api/_utils/accountStore.test.ts
+++ b/api/_utils/accountStore.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { generateLinkToken, linkBlobPath, indexBlobPath } from './accountStore';
+import { hashToken } from './feedUtils';
+
+describe('generateLinkToken', () => {
+  it('produces a URL-safe token of meaningful length', () => {
+    const token = generateLinkToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/); // base64url
+    expect(token.length).toBeGreaterThanOrEqual(40); // 32 bytes -> ~43 chars
+  });
+
+  it('produces a unique token each call', () => {
+    const tokens = new Set(Array.from({ length: 100 }, () => generateLinkToken()));
+    expect(tokens.size).toBe(100);
+  });
+});
+
+describe('blob path helpers', () => {
+  it('derives the link blob path from the token hash (never the raw token)', () => {
+    const token = generateLinkToken();
+    const path = linkBlobPath(token);
+    expect(path).toBe(`accounts/links/${hashToken(token)}.json`);
+    expect(path).not.toContain(token); // raw token never appears in the path
+  });
+
+  it('derives the account index path from the emailHash', () => {
+    expect(indexBlobPath('deadbeef')).toBe('accounts/index/deadbeef.json');
+  });
+});

--- a/api/_utils/accountStore.ts
+++ b/api/_utils/accountStore.ts
@@ -1,0 +1,138 @@
+// Blob-backed storage for email magic-link auth.
+//
+// Two namespaces, both stored as public Vercel Blobs (the SDK has no private mode) but with
+// UNGUESSABLE pathnames so they're effectively private:
+//   accounts/links/<sha256(rawToken)>.json  — single-use magic-link records, deleted on redeem.
+//       Path entropy = 256-bit random token hash. Content carries only emailHash (never raw email).
+//   accounts/index/<emailHash>.json          — per-account feed list. Path = keyed HMAC (unguessable
+//       without the server key); content is just feed GUIDs, which are already public.
+// External callers cannot list() (needs BLOB_READ_WRITE_TOKEN) and cannot guess the store
+// subdomain + high-entropy path, so neither namespace is enumerable.
+import { put, list, del } from '@vercel/blob';
+import { randomBytes } from 'crypto';
+import { hashToken } from './feedUtils.js';
+
+export type MagicLinkPurpose = 'login' | 'claim';
+
+export interface MagicLinkRecord {
+  emailHash: string;
+  purpose: MagicLinkPurpose;
+  feedId?: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface AccountIndex {
+  emailHash: string;
+  feedIds: string[];
+  updatedAt: number;
+}
+
+/** 32 bytes of CSPRNG, base64url — the raw token that travels in the emailed link URL. */
+export function generateLinkToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/** Blob path for a magic-link record, keyed by the token's hash (raw token never stored). */
+export function linkBlobPath(rawToken: string): string {
+  return `accounts/links/${hashToken(rawToken)}.json`;
+}
+
+/** Blob path for an account's feed index, keyed by emailHash. */
+export function indexBlobPath(emailHashHex: string): string {
+  return `accounts/index/${emailHashHex}.json`;
+}
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const text = await response.text();
+    return text ? (JSON.parse(text) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a single-use magic-link record and return the raw token to embed in the email URL.
+ */
+export async function storeMagicLink(params: {
+  emailHash: string;
+  purpose: MagicLinkPurpose;
+  feedId?: string;
+  ttlMs: number;
+}): Promise<string> {
+  const rawToken = generateLinkToken();
+  const now = Date.now();
+  const record: MagicLinkRecord = {
+    emailHash: params.emailHash,
+    purpose: params.purpose,
+    feedId: params.feedId,
+    createdAt: now,
+    expiresAt: now + params.ttlMs
+  };
+  await put(linkBlobPath(rawToken), JSON.stringify(record), {
+    access: 'public',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+    allowOverwrite: true
+  });
+  return rawToken;
+}
+
+/**
+ * Redeem a magic-link token: validate it exists and is unexpired, then DELETE it (single-use).
+ * Returns the record, or null if missing/expired. Deletes expired records as a side effect.
+ */
+export async function redeemMagicLink(rawToken: string): Promise<MagicLinkRecord | null> {
+  const path = linkBlobPath(rawToken);
+  const { blobs } = await list({ prefix: path });
+  const blob = blobs.find(b => b.pathname === path);
+  if (!blob) return null;
+
+  const record = await fetchJson<MagicLinkRecord>(blob.url);
+  // Always delete on lookup — single-use semantics, and expired records get cleaned up.
+  await del(blob.url).catch(() => { /* best-effort */ });
+
+  if (!record || Date.now() > record.expiresAt) return null;
+  return record;
+}
+
+/** Read an account's feed index (empty list if none). */
+export async function getAccountFeedIds(emailHashHex: string): Promise<string[]> {
+  const path = indexBlobPath(emailHashHex);
+  const { blobs } = await list({ prefix: path });
+  const blob = blobs.find(b => b.pathname === path);
+  if (!blob) return [];
+  const index = await fetchJson<AccountIndex>(blob.url);
+  return index?.feedIds ?? [];
+}
+
+async function writeAccountIndex(emailHashHex: string, feedIds: string[]): Promise<void> {
+  const index: AccountIndex = {
+    emailHash: emailHashHex,
+    feedIds: Array.from(new Set(feedIds)),
+    updatedAt: Date.now()
+  };
+  await put(indexBlobPath(emailHashHex), JSON.stringify(index), {
+    access: 'public',
+    contentType: 'application/json',
+    addRandomSuffix: false,
+    allowOverwrite: true
+  });
+}
+
+/** Add a feedId to an account's index (idempotent). */
+export async function addFeedToAccount(emailHashHex: string, feedId: string): Promise<void> {
+  const current = await getAccountFeedIds(emailHashHex);
+  if (current.includes(feedId)) return;
+  await writeAccountIndex(emailHashHex, [...current, feedId]);
+}
+
+/** Remove a feedId from an account's index (idempotent). */
+export async function removeFeedFromAccount(emailHashHex: string, feedId: string): Promise<void> {
+  const current = await getAccountFeedIds(emailHashHex);
+  if (!current.includes(feedId)) return;
+  await writeAccountIndex(emailHashHex, current.filter(id => id !== feedId));
+}

--- a/api/_utils/emailAuth.test.ts
+++ b/api/_utils/emailAuth.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  normalizeEmail,
+  emailHash,
+  signSession,
+  verifySession,
+  parseEmailAuthHeader
+} from './emailAuth';
+
+const HASH_KEY = 'test-email-hash-key-0000000000000000';
+const SESSION_SECRET = 'test-session-secret-1111111111111111';
+
+beforeEach(() => {
+  process.env.MSP_EMAIL_HASH_KEY = HASH_KEY;
+  process.env.MSP_SESSION_SECRET = SESSION_SECRET;
+});
+
+describe('normalizeEmail', () => {
+  it('trims surrounding whitespace and lowercases', () => {
+    expect(normalizeEmail('  Foo@Example.COM ')).toBe('foo@example.com');
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeEmail('  Foo@Example.COM ');
+    expect(normalizeEmail(once)).toBe(once);
+  });
+
+  it('applies Unicode NFC normalization', () => {
+    const nfd = 'josé@example.com'; // 'e' + combining acute accent (NFD)
+    const nfc = 'josé@example.com'; // precomposed 'é' (NFC)
+    expect(nfd).not.toBe(nfc); // sanity: byte sequences differ pre-normalization
+    expect(normalizeEmail(nfd)).toBe(nfc);
+  });
+});
+
+describe('emailHash', () => {
+  it('is deterministic for the same email', () => {
+    expect(emailHash('a@b.com')).toBe(emailHash('a@b.com'));
+  });
+
+  it('hashes the normalized form (case/whitespace-insensitive)', () => {
+    expect(emailHash('  A@B.com ')).toBe(emailHash('a@b.com'));
+  });
+
+  it('differs for different emails', () => {
+    expect(emailHash('a@b.com')).not.toBe(emailHash('c@d.com'));
+  });
+
+  it('is key-sensitive (different MSP_EMAIL_HASH_KEY -> different hash)', () => {
+    const withKey1 = emailHash('a@b.com');
+    process.env.MSP_EMAIL_HASH_KEY = 'a-completely-different-key-2222222222';
+    const withKey2 = emailHash('a@b.com');
+    expect(withKey1).not.toBe(withKey2);
+  });
+
+  it('does not contain the raw email', () => {
+    expect(emailHash('secret@private.com')).not.toContain('secret');
+  });
+});
+
+describe('signSession / verifySession', () => {
+  it('round-trips an emailHash', () => {
+    const eh = emailHash('a@b.com');
+    const token = signSession(eh);
+    const result = verifySession(token);
+    expect(result.valid).toBe(true);
+    expect(result.emailHash).toBe(eh);
+  });
+
+  it('rejects a tampered token', () => {
+    const token = signSession(emailHash('a@b.com'));
+    const tampered = token.slice(0, -3) + (token.slice(-3) === 'AAA' ? 'BBB' : 'AAA');
+    expect(verifySession(tampered).valid).toBe(false);
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const token = signSession(emailHash('a@b.com'));
+    process.env.MSP_SESSION_SECRET = 'rotated-secret-3333333333333333333333';
+    expect(verifySession(token).valid).toBe(false);
+  });
+
+  it('rejects an expired token', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      const token = signSession(emailHash('a@b.com'), { ttlMs: 1000 });
+      vi.setSystemTime(new Date('2026-01-01T00:00:02Z')); // +2s, past 1s ttl
+      expect(verifySession(token).valid).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(verifySession('not.a.jwt').valid).toBe(false);
+    expect(verifySession('').valid).toBe(false);
+  });
+});
+
+describe('parseEmailAuthHeader', () => {
+  it('parses a valid "Bearer <jwt>" header to the emailHash', () => {
+    const eh = emailHash('a@b.com');
+    const token = signSession(eh);
+    const result = parseEmailAuthHeader(`Bearer ${token}`);
+    expect(result.valid).toBe(true);
+    expect(result.emailHash).toBe(eh);
+  });
+
+  it('rejects a missing header', () => {
+    expect(parseEmailAuthHeader(undefined).valid).toBe(false);
+  });
+
+  it('rejects a non-Bearer scheme', () => {
+    const token = signSession(emailHash('a@b.com'));
+    expect(parseEmailAuthHeader(`Nostr ${token}`).valid).toBe(false);
+  });
+});

--- a/api/_utils/emailAuth.ts
+++ b/api/_utils/emailAuth.ts
@@ -1,0 +1,119 @@
+// Email magic-link authentication helpers (non-Nostr ownership path for hosted feeds).
+//
+// Security model: the raw email is NEVER persisted server-side. Ownership and sessions
+// reference only `emailHash` — a keyed HMAC of the normalized address — so nothing
+// reversible to a real email ever lands in a (public) Vercel Blob. Sessions are
+// stateless signed JWTs (HS256), mirroring the stateless-Nostr choice in adminAuth.ts.
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export interface EmailAuthResult {
+  valid: boolean;
+  emailHash?: string;
+  error?: string;
+}
+
+// Default session lifetime: 30 days.
+const DEFAULT_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Normalize an email for hashing/comparison: trim, lowercase, Unicode NFC.
+ * Deterministic and idempotent so the same human address always maps to one hash.
+ */
+export function normalizeEmail(raw: string): string {
+  return raw.trim().toLowerCase().normalize('NFC');
+}
+
+function getHashKey(): string {
+  const key = process.env.MSP_EMAIL_HASH_KEY;
+  if (!key) {
+    throw new Error('MSP_EMAIL_HASH_KEY not configured');
+  }
+  return key;
+}
+
+function getSessionSecret(): string {
+  const secret = process.env.MSP_SESSION_SECRET;
+  if (!secret) {
+    throw new Error('MSP_SESSION_SECRET not configured');
+  }
+  return secret;
+}
+
+/**
+ * Opaque, keyed HMAC-SHA256 of the normalized email (hex). Stored in feed metadata
+ * as `ownerEmailHash` and used as the account index key. Not reversible without the key.
+ */
+export function emailHash(email: string): string {
+  return createHmac('sha256', getHashKey())
+    .update(normalizeEmail(email))
+    .digest('hex');
+}
+
+function b64urlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+/**
+ * Mint a stateless HS256 session JWT carrying the emailHash as `sub`.
+ * Verified server-side on hosted writes via the `X-Email-Session` header.
+ */
+export function signSession(emailHashHex: string, opts: { ttlMs?: number } = {}): string {
+  const now = Date.now();
+  const ttlMs = opts.ttlMs ?? DEFAULT_SESSION_TTL_MS;
+  const headerB64 = b64urlJson({ alg: 'HS256', typ: 'JWT' });
+  const payloadB64 = b64urlJson({
+    sub: emailHashHex,
+    iat: Math.floor(now / 1000),
+    exp: Math.floor((now + ttlMs) / 1000)
+  });
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const sig = createHmac('sha256', getSessionSecret()).update(signingInput).digest('base64url');
+  return `${signingInput}.${sig}`;
+}
+
+/**
+ * Verify a session JWT: constant-time signature check, then expiry. Returns the emailHash on success.
+ */
+export function verifySession(token: string): EmailAuthResult {
+  if (!token || typeof token !== 'string') {
+    return { valid: false, error: 'Missing token' };
+  }
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return { valid: false, error: 'Malformed token' };
+  }
+  const [headerB64, payloadB64, sig] = parts;
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const expectedSig = createHmac('sha256', getSessionSecret()).update(signingInput).digest('base64url');
+
+  const sigBuf = Buffer.from(sig);
+  const expBuf = Buffer.from(expectedSig);
+  if (sigBuf.length !== expBuf.length || !timingSafeEqual(sigBuf, expBuf)) {
+    return { valid: false, error: 'Invalid signature' };
+  }
+
+  let payload: { sub?: string; exp?: number };
+  try {
+    payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf-8'));
+  } catch {
+    return { valid: false, error: 'Invalid payload' };
+  }
+
+  if (typeof payload.exp === 'number' && Date.now() / 1000 > payload.exp) {
+    return { valid: false, error: 'Token expired' };
+  }
+  if (!payload.sub) {
+    return { valid: false, error: 'Missing subject' };
+  }
+  return { valid: true, emailHash: payload.sub };
+}
+
+/**
+ * Parse an `Authorization: Bearer <jwt>` / `X-Email-Session: Bearer <jwt>` header.
+ */
+export function parseEmailAuthHeader(header: string | undefined): EmailAuthResult {
+  if (!header || !header.startsWith('Bearer ')) {
+    return { valid: false, error: 'Missing or invalid auth header' };
+  }
+  return verifySession(header.slice(7));
+}

--- a/api/_utils/feedHydrate.ts
+++ b/api/_utils/feedHydrate.ts
@@ -1,0 +1,63 @@
+// Shared hosted-feed hydration: given a feedId + its blob URLs, build the listing object
+// (meta fields + author/medium extracted from the XML + a lazily-resolved Podcast Index id).
+// Used by both the Nostr "list my feeds" path (api/hosted GET) and the email-account path
+// (api/account/feeds) so both return an identical shape.
+import { list, put } from '@vercel/blob';
+import { lookupPodcastIndexId } from './feedUtils.js';
+import { extractPodcastMedium } from './xmlUtils.js';
+
+export interface HydratedFeed {
+  feedId: string;
+  author?: string;
+  medium?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Hydrate one feed from its meta + (optional) xml blob URLs.
+ * Mirrors the original inline logic in api/hosted/index.ts so the listing shape is unchanged.
+ */
+export async function hydrateFeed(feedId: string, metaUrl: string, xmlUrl?: string): Promise<HydratedFeed> {
+  const metaResponse = await fetch(metaUrl);
+  const metaText = await metaResponse.text();
+  const meta = metaText ? JSON.parse(metaText) : {};
+
+  let author: string | undefined;
+  let medium: string | undefined;
+  if (xmlUrl) {
+    try {
+      const xml = await (await fetch(xmlUrl)).text();
+      const authorMatch = xml.match(/<itunes:author>([^<]+)<\/itunes:author>/);
+      if (authorMatch) author = authorMatch[1];
+      const extractedMedium = extractPodcastMedium(xml);
+      if (extractedMedium) medium = extractedMedium;
+    } catch {
+      // Ignore errors extracting metadata
+    }
+  }
+
+  let podcastIndexId = meta.podcastIndexId;
+  if (!podcastIndexId) {
+    podcastIndexId = await lookupPodcastIndexId(feedId);
+    if (podcastIndexId) {
+      put(`feeds/${feedId}.meta.json`, JSON.stringify({ ...meta, podcastIndexId }), {
+        access: 'public',
+        contentType: 'application/json',
+        addRandomSuffix: false
+      }).catch(err => console.warn('Failed to update metadata with PI ID:', err));
+    }
+  }
+
+  return { feedId, author, medium, ...meta, podcastIndexId };
+}
+
+/**
+ * Hydrate a feed by id, listing its blobs first. Returns null if the feed has no metadata.
+ */
+export async function hydrateFeedById(feedId: string): Promise<HydratedFeed | null> {
+  const { blobs } = await list({ prefix: `feeds/${feedId}` });
+  const metaBlob = blobs.find(b => b.pathname === `feeds/${feedId}.meta.json`);
+  if (!metaBlob) return null;
+  const xmlBlob = blobs.find(b => b.pathname === `feeds/${feedId}.xml` && !b.pathname.includes('.backup.'));
+  return hydrateFeed(feedId, metaBlob.url, xmlBlob?.url);
+}

--- a/api/_utils/sendEmail.test.ts
+++ b/api/_utils/sendEmail.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { isEmailConfigured } from './sendEmail';
+
+const ORIGINAL = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.RESEND_API_KEY;
+  delete process.env.MSP_EMAIL_FROM;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL };
+});
+
+describe('isEmailConfigured', () => {
+  it('is false when neither RESEND_API_KEY nor MSP_EMAIL_FROM is set', () => {
+    expect(isEmailConfigured()).toBe(false);
+  });
+
+  it('is false when only one of the two is set', () => {
+    process.env.RESEND_API_KEY = 're_test';
+    expect(isEmailConfigured()).toBe(false);
+    delete process.env.RESEND_API_KEY;
+    process.env.MSP_EMAIL_FROM = 'noreply@musicsideproject.com';
+    expect(isEmailConfigured()).toBe(false);
+  });
+
+  it('is true when both are set', () => {
+    process.env.RESEND_API_KEY = 're_test';
+    process.env.MSP_EMAIL_FROM = 'noreply@musicsideproject.com';
+    expect(isEmailConfigured()).toBe(true);
+  });
+});

--- a/api/_utils/sendEmail.ts
+++ b/api/_utils/sendEmail.ts
@@ -1,0 +1,89 @@
+// Thin Resend email sender for magic-link auth. Send-only (no inbound/MX needed).
+// No-ops with a console.warn when unconfigured, mirroring the isPodpingConfigured() gate
+// in feedUtils.ts so local dev without keys doesn't throw.
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+
+export interface SendEmailResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+/**
+ * True when both RESEND_API_KEY and MSP_EMAIL_FROM are set. Callers short-circuit otherwise.
+ */
+export function isEmailConfigured(): boolean {
+  return Boolean(process.env.RESEND_API_KEY && process.env.MSP_EMAIL_FROM);
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderMagicLinkEmail(link: string, ctx: { feedTitle?: string; purpose: 'login' | 'claim' }): { subject: string; html: string; text: string } {
+  const safeLink = escapeHtml(link);
+  const action = ctx.purpose === 'claim'
+    ? `claim ${ctx.feedTitle ? `"${escapeHtml(ctx.feedTitle)}"` : 'your feed'}`
+    : 'sign in to Music Side Project';
+  const subject = ctx.purpose === 'claim'
+    ? `Claim your MSP feed`
+    : `Sign in to Music Side Project`;
+  const text = `Click to ${action}:\n\n${link}\n\nThis link expires shortly and can only be used once. If you didn't request it, you can ignore this email.`;
+  const html = `<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">
+<p>Click the button below to ${action}.</p>
+<p><a href="${safeLink}" style="display:inline-block;padding:10px 18px;background:#7c3aed;color:#fff;border-radius:6px;text-decoration:none">Continue</a></p>
+<p style="color:#666;font-size:13px">Or paste this URL into your browser:<br>${safeLink}</p>
+<p style="color:#999;font-size:12px">This link expires shortly and can only be used once. If you didn't request it, ignore this email.</p>
+</body></html>`;
+  return { subject, html, text };
+}
+
+/**
+ * Send a magic-link email via Resend. Returns ok:false (no throw) when unconfigured or on failure,
+ * so callers can decide how to surface it without leaking whether an address exists.
+ */
+export async function sendMagicLinkEmail(
+  to: string,
+  link: string,
+  ctx: { feedTitle?: string; purpose: 'login' | 'claim' }
+): Promise<SendEmailResult> {
+  if (!isEmailConfigured()) {
+    console.warn('sendMagicLinkEmail: RESEND_API_KEY/MSP_EMAIL_FROM not configured — skipping send');
+    return { ok: false, error: 'Email not configured' };
+  }
+
+  const { subject, html, text } = renderMagicLinkEmail(link, ctx);
+
+  try {
+    const response = await fetch(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        from: process.env.MSP_EMAIL_FROM,
+        to,
+        subject,
+        html,
+        text
+      })
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      console.warn(`Resend send failed: ${response.status} ${body}`);
+      return { ok: false, status: response.status, error: body || response.statusText };
+    }
+
+    return { ok: true, status: response.status };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn('Failed to send magic-link email:', message);
+    return { ok: false, error: message };
+  }
+}

--- a/api/account/feeds.test.ts
+++ b/api/account/feeds.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetFeedIds = vi.fn();
+vi.mock('../_utils/accountStore.js', () => ({
+  getAccountFeedIds: (...a: unknown[]) => mockGetFeedIds(...a)
+}));
+
+const mockHydrate = vi.fn();
+vi.mock('../_utils/feedHydrate.js', () => ({
+  hydrateFeedById: (...a: unknown[]) => mockHydrate(...a)
+}));
+
+import { signSession } from '../_utils/emailAuth';
+
+function mockReqRes(method: string, headers: Record<string, string> = {}) {
+  const req = { method, headers } as any;
+  const res = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() } as any;
+  return { req, res };
+}
+
+describe('/api/account/feeds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MSP_SESSION_SECRET = 'test-session-secret-bbbbbbbbbbbbbbbb';
+  });
+
+  it('rejects non-GET with 405', async () => {
+    const { default: handler } = await import('./feeds');
+    const { req, res } = mockReqRes('POST');
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('rejects a missing session with 401', async () => {
+    const { default: handler } = await import('./feeds');
+    const { req, res } = mockReqRes('GET');
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects an invalid session token with 401', async () => {
+    const { default: handler } = await import('./feeds');
+    const { req, res } = mockReqRes('GET', { 'x-email-session': 'Bearer garbage.token.here' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('returns the account feeds for a valid session', async () => {
+    mockGetFeedIds.mockResolvedValue(['feed-a', 'feed-b']);
+    mockHydrate.mockImplementation(async (id: string) => ({ feedId: id, title: id }));
+    const session = signSession('abc123');
+    const { default: handler } = await import('./feeds');
+    const { req, res } = mockReqRes('GET', { 'x-email-session': `Bearer ${session}` });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.count).toBe(2);
+    expect(payload.feeds.map((f: { feedId: string }) => f.feedId)).toEqual(['feed-a', 'feed-b']);
+  });
+
+  it('drops feeds that no longer resolve', async () => {
+    mockGetFeedIds.mockResolvedValue(['feed-a', 'gone']);
+    mockHydrate.mockImplementation(async (id: string) => (id === 'gone' ? null : { feedId: id }));
+    const session = signSession('abc123');
+    const { default: handler } = await import('./feeds');
+    const { req, res } = mockReqRes('GET', { 'x-email-session': `Bearer ${session}` });
+    await handler(req, res);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.count).toBe(1);
+  });
+});

--- a/api/account/feeds.ts
+++ b/api/account/feeds.ts
@@ -1,0 +1,30 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { parseEmailAuthHeader } from '../_utils/emailAuth.js';
+import { getAccountFeedIds } from '../_utils/accountStore.js';
+import { hydrateFeedById } from '../_utils/feedHydrate.js';
+
+/**
+ * List the feeds owned by the authenticated email account.
+ * Auth: X-Email-Session: Bearer <jwt>. Returns the same feed shape as the Nostr list path.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const header = req.headers['x-email-session'];
+  const auth = parseEmailAuthHeader(Array.isArray(header) ? header[0] : header);
+  if (!auth.valid || !auth.emailHash) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  try {
+    const feedIds = await getAccountFeedIds(auth.emailHash);
+    const hydrated = await Promise.all(feedIds.map(id => hydrateFeedById(id)));
+    const feeds = hydrated.filter(Boolean);
+    return res.status(200).json({ feeds, count: feeds.length });
+  } catch (err) {
+    console.error('account feeds error:', err instanceof Error ? err.message : err);
+    return res.status(500).json({ error: 'Failed to list feeds' });
+  }
+}

--- a/api/auth/magic-link.test.ts
+++ b/api/auth/magic-link.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockList = vi.fn();
+vi.mock('@vercel/blob', () => ({ list: mockList, put: vi.fn(), del: vi.fn() }));
+
+const mockStoreMagicLink = vi.fn();
+vi.mock('../_utils/accountStore.js', () => ({
+  storeMagicLink: (...args: unknown[]) => mockStoreMagicLink(...args)
+}));
+
+const mockSend = vi.fn();
+vi.mock('../_utils/sendEmail.js', () => ({
+  sendMagicLinkEmail: (...args: unknown[]) => mockSend(...args)
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { hashToken } from '../_utils/feedUtils';
+
+function mockReqRes(method: string, body: unknown, ip = '9.9.9.9') {
+  const req = { method, body, headers: { 'x-forwarded-for': ip } } as any;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    setHeader: vi.fn().mockReturnThis()
+  } as any;
+  return { req, res };
+}
+
+const VALID_FEED_ID = '11111111-2222-3333-4444-555555555555';
+
+describe('/api/auth/magic-link', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.MSP_EMAIL_HASH_KEY = 'test-hash-key-aaaaaaaaaaaaaaaaaaaa';
+    process.env.MSP_SESSION_SECRET = 'test-session-secret-bbbbbbbbbbbbbbbb';
+    mockStoreMagicLink.mockResolvedValue('raw-link-token');
+    mockSend.mockResolvedValue({ ok: true });
+    const { __resetRateLimiterForTests } = await import('../_utils/rateLimiter');
+    __resetRateLimiterForTests();
+  });
+
+  it('rejects non-POST with 405', async () => {
+    const { default: handler } = await import('./magic-link');
+    const { req, res } = mockReqRes('GET', {});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('rejects a missing/invalid email with 400', async () => {
+    const { default: handler } = await import('./magic-link');
+    const { req, res } = mockReqRes('POST', { email: 'not-an-email' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 200 {sent:true} and sends for a valid login email', async () => {
+    const { default: handler } = await import('./magic-link');
+    const { req, res } = mockReqRes('POST', { email: 'fan@example.com', purpose: 'login' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ sent: true });
+    expect(mockSend).toHaveBeenCalledOnce();
+  });
+
+  it('is enumeration-safe (same 200 response regardless of address)', async () => {
+    const { default: handler } = await import('./magic-link');
+    const a = mockReqRes('POST', { email: 'known@example.com' });
+    const b = mockReqRes('POST', { email: 'unknown@example.com' }, '8.8.8.8');
+    await handler(a.req, a.res);
+    await handler(b.req, b.res);
+    expect(a.res.status).toHaveBeenCalledWith(200);
+    expect(b.res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('rate-limits repeated requests from the same IP/email with 429', async () => {
+    const { default: handler } = await import('./magic-link');
+    for (let i = 0; i < 5; i++) {
+      const { req, res } = mockReqRes('POST', { email: 'spam@example.com' });
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    }
+    const sixth = mockReqRes('POST', { email: 'spam@example.com' });
+    await handler(sixth.req, sixth.res);
+    expect(sixth.res.status).toHaveBeenCalledWith(429);
+  });
+
+  it('rejects a claim without feedId/editToken (400)', async () => {
+    const { default: handler } = await import('./magic-link');
+    const { req, res } = mockReqRes('POST', { email: 'owner@example.com', purpose: 'claim' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockStoreMagicLink).not.toHaveBeenCalled();
+  });
+
+  it('rejects a claim with the wrong edit token (403)', async () => {
+    mockList.mockResolvedValue({ blobs: [{ pathname: `feeds/${VALID_FEED_ID}.meta.json`, url: 'https://blob/meta' }] });
+    mockFetch.mockResolvedValue({ json: async () => ({ editTokenHash: hashToken('the-real-token'), title: 'My Feed' }) });
+    const { default: handler } = await import('./magic-link');
+    const { req, res } = mockReqRes('POST', { email: 'attacker@example.com', purpose: 'claim', feedId: VALID_FEED_ID, editToken: 'wrong-token-aaaaaaaaaaaaaaaaaaaaaaaa' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockStoreMagicLink).not.toHaveBeenCalled();
+  });
+
+  it('accepts a claim with the correct edit token and stores a claim link', async () => {
+    mockList.mockResolvedValue({ blobs: [{ pathname: `feeds/${VALID_FEED_ID}.meta.json`, url: 'https://blob/meta' }] });
+    mockFetch.mockResolvedValue({ json: async () => ({ editTokenHash: hashToken('the-real-token'), title: 'My Feed' }) });
+    const { default: handler } = await import('./magic-link');
+    const { req, res } = mockReqRes('POST', { email: 'owner@example.com', purpose: 'claim', feedId: VALID_FEED_ID, editToken: 'the-real-token' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockStoreMagicLink).toHaveBeenCalledWith(expect.objectContaining({ purpose: 'claim', feedId: VALID_FEED_ID }));
+  });
+});

--- a/api/auth/magic-link.ts
+++ b/api/auth/magic-link.ts
@@ -1,0 +1,90 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { list } from '@vercel/blob';
+import { normalizeEmail, emailHash } from '../_utils/emailAuth.js';
+import { storeMagicLink, type MagicLinkPurpose } from '../_utils/accountStore.js';
+import { sendMagicLinkEmail } from '../_utils/sendEmail.js';
+import { getBaseUrl, hashToken, timingSafeEqualHex, isValidFeedId } from '../_utils/feedUtils.js';
+import { checkRateLimit } from '../_utils/rateLimiter.js';
+
+// Basic shape check — real validation is "can you receive the email".
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function getClientIp(req: VercelRequest): string {
+  const fwd = req.headers['x-forwarded-for'];
+  const raw = Array.isArray(fwd) ? fwd[0] : fwd;
+  return (raw?.split(',')[0] || 'unknown').trim();
+}
+
+function magicLinkTtlMs(): number {
+  const min = Number(process.env.MSP_MAGIC_LINK_TTL_MIN) || 15;
+  return min * 60 * 1000;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { email, purpose, feedId, editToken } = (req.body ?? {}) as {
+    email?: string;
+    purpose?: MagicLinkPurpose;
+    feedId?: string;
+    editToken?: string;
+  };
+
+  if (!email || typeof email !== 'string' || !EMAIL_RE.test(email.trim())) {
+    return res.status(400).json({ error: 'Valid email required' });
+  }
+  const resolvedPurpose: MagicLinkPurpose = purpose === 'claim' ? 'claim' : 'login';
+  const normalized = normalizeEmail(email);
+  const eHash = emailHash(normalized);
+
+  // Rate limit by IP and by target email so neither can be abused.
+  const ip = getClientIp(req);
+  const ipLimit = checkRateLimit(`magiclink:ip:${ip}`, { limit: 5, windowMs: 15 * 60 * 1000 });
+  const emailLimit = checkRateLimit(`magiclink:email:${eHash}`, { limit: 5, windowMs: 15 * 60 * 1000 });
+  if (!ipLimit.allowed || !emailLimit.allowed) {
+    const retryAfterMs = Math.max(ipLimit.retryAfterMs, emailLimit.retryAfterMs);
+    res.setHeader('Retry-After', Math.ceil(retryAfterMs / 1000).toString());
+    return res.status(429).json({ error: 'Too many requests. Try again later.' });
+  }
+
+  let feedTitle: string | undefined;
+
+  // For a claim, the requester must prove they currently own the feed (edit token),
+  // otherwise anyone could attach their email to someone else's hosted feed.
+  if (resolvedPurpose === 'claim') {
+    if (!feedId || !isValidFeedId(feedId) || !editToken || typeof editToken !== 'string') {
+      return res.status(400).json({ error: 'feedId and editToken required to claim a feed' });
+    }
+    const path = `feeds/${feedId}.meta.json`;
+    const { blobs } = await list({ prefix: path });
+    const metaBlob = blobs.find(b => b.pathname === path);
+    if (!metaBlob) {
+      return res.status(404).json({ error: 'Feed not found' });
+    }
+    const meta = await (await fetch(metaBlob.url)).json().catch(() => null) as { editTokenHash?: string; title?: string } | null;
+    if (!meta?.editTokenHash || !timingSafeEqualHex(meta.editTokenHash, hashToken(editToken))) {
+      return res.status(403).json({ error: 'Invalid edit token for this feed' });
+    }
+    feedTitle = meta.title;
+  }
+
+  try {
+    const rawToken = await storeMagicLink({
+      emailHash: eHash,
+      purpose: resolvedPurpose,
+      feedId: resolvedPurpose === 'claim' ? feedId : undefined,
+      ttlMs: magicLinkTtlMs()
+    });
+    const link = `${getBaseUrl()}/auth/verify?token=${encodeURIComponent(rawToken)}`;
+    await sendMagicLinkEmail(normalized, link, { purpose: resolvedPurpose, feedTitle });
+  } catch (err) {
+    console.error('magic-link error:', err instanceof Error ? err.message : err);
+    // Fall through to the generic 200 below — never reveal internal/account state.
+  }
+
+  // Always 200 (no account enumeration). Whether or not the email exists/owns
+  // anything, the response is identical.
+  return res.status(200).json({ sent: true });
+}

--- a/api/auth/magic-link.ts
+++ b/api/auth/magic-link.ts
@@ -20,6 +20,27 @@ function magicLinkTtlMs(): number {
   return min * 60 * 1000;
 }
 
+/**
+ * Origin to send the user back to. A magic link should return you to the site you're
+ * actually using (the canonical domain in prod, or a Vercel preview during testing) —
+ * NOT a hardcoded domain. The host is allowlisted (canonical host or a *.vercel.app
+ * preview) to prevent host-header injection pointing the link at an attacker domain;
+ * anything else falls back to the canonical URL.
+ */
+function getVerifyOrigin(req: VercelRequest): string {
+  const canonical = getBaseUrl();
+  const rawHost = req.headers['x-forwarded-host'] || req.headers.host;
+  const host = (Array.isArray(rawHost) ? rawHost[0] : rawHost)?.split(',')[0]?.trim();
+  if (host) {
+    const canonicalHost = new URL(canonical).host;
+    if (host === canonicalHost || host.endsWith('.vercel.app')) {
+      const proto = (req.headers['x-forwarded-proto'] as string)?.split(',')[0]?.trim() || 'https';
+      return `${proto}://${host}`;
+    }
+  }
+  return canonical;
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -77,7 +98,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       feedId: resolvedPurpose === 'claim' ? feedId : undefined,
       ttlMs: magicLinkTtlMs()
     });
-    const link = `${getBaseUrl()}/auth/verify?token=${encodeURIComponent(rawToken)}`;
+    const link = `${getVerifyOrigin(req)}/auth/verify?token=${encodeURIComponent(rawToken)}`;
     await sendMagicLinkEmail(normalized, link, { purpose: resolvedPurpose, feedTitle });
   } catch (err) {
     console.error('magic-link error:', err instanceof Error ? err.message : err);

--- a/api/auth/verify.test.ts
+++ b/api/auth/verify.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockList = vi.fn();
+const mockPut = vi.fn();
+vi.mock('@vercel/blob', () => ({ list: mockList, put: mockPut, del: vi.fn() }));
+
+const mockRedeem = vi.fn();
+const mockAddFeed = vi.fn();
+vi.mock('../_utils/accountStore.js', () => ({
+  redeemMagicLink: (...a: unknown[]) => mockRedeem(...a),
+  addFeedToAccount: (...a: unknown[]) => mockAddFeed(...a)
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { verifySession } from '../_utils/emailAuth';
+
+function mockReqRes(method: string, body: unknown) {
+  const req = { method, body, headers: {} } as any;
+  const res = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() } as any;
+  return { req, res };
+}
+
+const EMAIL_HASH = 'abc123';
+const FEED_ID = '11111111-2222-3333-4444-555555555555';
+
+describe('/api/auth/verify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MSP_SESSION_SECRET = 'test-session-secret-bbbbbbbbbbbbbbbb';
+    mockPut.mockResolvedValue({});
+    mockAddFeed.mockResolvedValue(undefined);
+  });
+
+  it('rejects non-POST with 405', async () => {
+    const { default: handler } = await import('./verify');
+    const { req, res } = mockReqRes('GET', {});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it('rejects a missing token with 400', async () => {
+    const { default: handler } = await import('./verify');
+    const { req, res } = mockReqRes('POST', {});
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects an invalid/expired token with 400', async () => {
+    mockRedeem.mockResolvedValue(null);
+    const { default: handler } = await import('./verify');
+    const { req, res } = mockReqRes('POST', { token: 'expired' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('mints a valid session for a login link', async () => {
+    mockRedeem.mockResolvedValue({ purpose: 'login', emailHash: EMAIL_HASH });
+    const { default: handler } = await import('./verify');
+    const { req, res } = mockReqRes('POST', { token: 'good' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.emailHash).toBe(EMAIL_HASH);
+    const v = verifySession(payload.session);
+    expect(v.valid).toBe(true);
+    expect(v.emailHash).toBe(EMAIL_HASH);
+    expect(mockPut).not.toHaveBeenCalled(); // login does not touch feed meta
+  });
+
+  it('stamps ownerEmailHash and indexes the feed for a claim link', async () => {
+    mockRedeem.mockResolvedValue({ purpose: 'claim', emailHash: EMAIL_HASH, feedId: FEED_ID });
+    mockList.mockResolvedValue({ blobs: [{ pathname: `feeds/${FEED_ID}.meta.json`, url: 'https://blob/meta' }] });
+    mockFetch.mockResolvedValue({ json: async () => ({ editTokenHash: 'x', title: 'Feed' }) });
+    const { default: handler } = await import('./verify');
+    const { req, res } = mockReqRes('POST', { token: 'good-claim' });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockPut).toHaveBeenCalledOnce();
+    const written = JSON.parse(mockPut.mock.calls[0][1]);
+    expect(written.ownerEmailHash).toBe(EMAIL_HASH);
+    expect(written.emailLinkedAt).toBeTruthy();
+    expect(mockAddFeed).toHaveBeenCalledWith(EMAIL_HASH, FEED_ID);
+  });
+});

--- a/api/auth/verify.ts
+++ b/api/auth/verify.ts
@@ -1,0 +1,53 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { list, put } from '@vercel/blob';
+import { signSession } from '../_utils/emailAuth.js';
+import { redeemMagicLink, addFeedToAccount } from '../_utils/accountStore.js';
+
+/**
+ * Redeem a magic-link token (single-use) and mint a session.
+ * For a 'claim' link, also stamps ownerEmailHash onto the feed and indexes it to the account.
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { token } = (req.body ?? {}) as { token?: string };
+  if (!token || typeof token !== 'string') {
+    return res.status(400).json({ error: 'Missing token' });
+  }
+
+  const record = await redeemMagicLink(token);
+  if (!record) {
+    return res.status(400).json({ error: 'This link is invalid or has expired. Request a new one.' });
+  }
+
+  // Claim links carry a feedId: attach the email as owner and index it to the account.
+  if (record.purpose === 'claim' && record.feedId) {
+    try {
+      const path = `feeds/${record.feedId}.meta.json`;
+      const { blobs } = await list({ prefix: path });
+      const metaBlob = blobs.find(b => b.pathname === path);
+      if (metaBlob) {
+        const meta = await (await fetch(metaBlob.url)).json().catch(() => ({}));
+        await put(path, JSON.stringify({
+          ...meta,
+          ownerEmailHash: record.emailHash,
+          emailLinkedAt: Date.now().toString()
+        }), {
+          access: 'public',
+          contentType: 'application/json',
+          addRandomSuffix: false,
+          allowOverwrite: true
+        });
+        await addFeedToAccount(record.emailHash, record.feedId);
+      }
+    } catch (err) {
+      console.error('verify claim error:', err instanceof Error ? err.message : err);
+      return res.status(500).json({ error: 'Failed to claim feed' });
+    }
+  }
+
+  const session = signSession(record.emailHash);
+  return res.status(200).json({ session, emailHash: record.emailHash });
+}

--- a/api/hosted/[feedId].ts
+++ b/api/hosted/[feedId].ts
@@ -9,6 +9,8 @@ import {
   isValidFeedId
 } from '../_utils/feedUtils.js';
 import { extractPodcastMedium } from '../_utils/xmlUtils.js';
+import { parseEmailAuthHeader } from '../_utils/emailAuth.js';
+import { addFeedToAccount, removeFeedFromAccount } from '../_utils/accountStore.js';
 
 // Metadata stored in separate .meta.json blob
 interface FeedMetadata {
@@ -16,10 +18,19 @@ interface FeedMetadata {
   createdAt: string;
   lastUpdated?: string;
   title?: string;
-  ownerPubkey?: string;  // Nostr pubkey (hex) - if linked
-  linkedAt?: string;     // When Nostr was linked
+  ownerPubkey?: string;      // Nostr pubkey (hex) - if linked
+  linkedAt?: string;         // When Nostr was linked
+  ownerEmailHash?: string;   // Keyed HMAC of the owner email - if claimed via email
+  emailLinkedAt?: string;    // When the email was linked
   podcastIndexId?: number;
-  isDraft?: boolean;     // True when hosted without PI/podping notification
+  isDraft?: boolean;         // True when hosted without PI/podping notification
+}
+
+// True when the X-Email-Session header carries a valid session for this feed's email owner.
+function emailSessionOwns(metadata: { ownerEmailHash?: string }, header: string | undefined): boolean {
+  if (!metadata.ownerEmailHash || !header) return false;
+  const auth = parseEmailAuthHeader(header);
+  return auth.valid && auth.emailHash === metadata.ownerEmailHash;
 }
 
 // Helper to fetch metadata from .meta.json blob
@@ -68,7 +79,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method === 'OPTIONS') {
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Edit-Token, Authorization, X-Admin-Key');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Edit-Token, Authorization, X-Admin-Key, X-Email-Session');
     return res.status(204).end();
   }
 
@@ -226,11 +237,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         let existingTitle: string | undefined;
         let ownerPubkey: string | undefined;
         let linkedAt: string | undefined;
+        let ownerEmailHash: string | undefined;
+        let emailLinkedAt: string | undefined;
         let existingPodcastIndexId: number | undefined;
         let existingIsDraft: boolean | undefined;
 
         const editToken = req.headers['x-edit-token'];
         const authHeader = req.headers['authorization'] as string | undefined;
+        const emailSessionHeader = req.headers['x-email-session'] as string | undefined;
 
         if (!metadata) {
           // Legacy feed without metadata - require token to migrate
@@ -242,6 +256,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           existingTitle = undefined;
           ownerPubkey = undefined;
           linkedAt = undefined;
+          ownerEmailHash = undefined;
+          emailLinkedAt = undefined;
           existingPodcastIndexId = undefined;
           existingIsDraft = undefined;
         } else {
@@ -250,10 +266,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           existingTitle = metadata.title;
           ownerPubkey = metadata.ownerPubkey;
           linkedAt = metadata.linkedAt;
+          ownerEmailHash = metadata.ownerEmailHash;
+          emailLinkedAt = metadata.emailLinkedAt;
           existingPodcastIndexId = metadata.podcastIndexId;
           existingIsDraft = metadata.isDraft;
 
-          // Validate auth: accept either token or Nostr (if linked)
+          // Validate auth: accept token, Nostr owner, or email-session owner.
           let isAuthorized = false;
 
           // Try token auth first
@@ -270,6 +288,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             if (nostrAuth.valid && nostrAuth.pubkey === ownerPubkey) {
               isAuthorized = true;
             }
+          }
+
+          // Try email-session auth if not yet authorized and feed has an email owner
+          if (!isAuthorized && emailSessionOwns(metadata, emailSessionHeader)) {
+            isAuthorized = true;
           }
 
           if (!isAuthorized) {
@@ -333,6 +356,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           title: (typeof title === 'string' ? title : existingTitle || 'Untitled Feed').slice(0, 200),
           ownerPubkey,
           linkedAt,
+          ownerEmailHash,
+          emailLinkedAt,
           podcastIndexId,
           ...(effectiveIsDraft && { isDraft: true })
         }), {
@@ -345,13 +370,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
 
       case 'PATCH': {
-        // Link Nostr identity to existing feed
-        // Requires BOTH token (proves ownership) AND Nostr auth (identity to link)
+        // Claim an existing feed by linking an identity to it.
+        // Requires the edit token (proves current ownership) PLUS the identity to attach:
+        // either an email session (X-Email-Session) or a Nostr auth event (Authorization: Nostr).
         const editToken = req.headers['x-edit-token'];
         const authHeader = req.headers['authorization'] as string | undefined;
+        const emailSessionHeader = req.headers['x-email-session'] as string | undefined;
 
         if (!editToken || typeof editToken !== 'string') {
-          return res.status(401).json({ error: 'Edit token required to link Nostr identity' });
+          return res.status(401).json({ error: 'Edit token required to link an identity' });
         }
 
         const metadata = await getMetadata(feedId as string);
@@ -365,13 +392,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           return res.status(403).json({ error: 'Invalid edit token' });
         }
 
-        // Parse and validate Nostr auth
-        const nostrAuth = await parseFeedAuthHeader(authHeader);
-        if (!nostrAuth.valid || !nostrAuth.pubkey) {
-          return res.status(400).json({ error: nostrAuth.error || 'Invalid Nostr authentication' });
+        // Determine which identity to attach. Email session takes precedence when present.
+        let updatedMeta: FeedMetadata;
+        let responseExtra: Record<string, unknown>;
+
+        if (emailSessionHeader) {
+          const emailAuth = parseEmailAuthHeader(emailSessionHeader);
+          if (!emailAuth.valid || !emailAuth.emailHash) {
+            return res.status(400).json({ error: emailAuth.error || 'Invalid email session' });
+          }
+          updatedMeta = {
+            ...metadata,
+            ownerEmailHash: emailAuth.emailHash,
+            emailLinkedAt: Date.now().toString()
+          };
+          responseExtra = { message: 'Email identity linked successfully', emailLinked: true };
+          await addFeedToAccount(emailAuth.emailHash, feedId as string);
+        } else {
+          const nostrAuth = await parseFeedAuthHeader(authHeader);
+          if (!nostrAuth.valid || !nostrAuth.pubkey) {
+            return res.status(400).json({ error: nostrAuth.error || 'Invalid Nostr authentication' });
+          }
+          updatedMeta = {
+            ...metadata,
+            ownerPubkey: nostrAuth.pubkey,
+            linkedAt: Date.now().toString()
+          };
+          responseExtra = { message: 'Nostr identity linked successfully', pubkey: nostrAuth.pubkey };
         }
 
-        // Update metadata with new owner
+        // Update metadata with the new owner
         const metaPath = `feeds/${feedId}.meta.json`;
         const { blobs: metaBlobs } = await list({ prefix: metaPath });
         const existingMeta = metaBlobs.find(b => b.pathname === metaPath);
@@ -379,43 +429,63 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           await del(existingMeta.url);
         }
 
-        await put(metaPath, JSON.stringify({
-          ...metadata,
-          ownerPubkey: nostrAuth.pubkey,
-          linkedAt: Date.now().toString()
-        }), {
+        await put(metaPath, JSON.stringify(updatedMeta), {
           access: 'public',
           contentType: 'application/json',
           addRandomSuffix: false
         });
 
-        return res.status(200).json({
-          success: true,
-          message: 'Nostr identity linked successfully',
-          pubkey: nostrAuth.pubkey
-        });
+        return res.status(200).json({ success: true, ...responseExtra });
       }
 
       case 'DELETE': {
-        // Admin can delete without edit token
+        // Fetch metadata once so both the auth check and the account-index cleanup can use it.
+        const metadata = await getMetadata(feedId as string);
+
+        // Admin can delete without any feed credential
         if (!isAdmin) {
-          // Validate edit token for non-admin
           const editToken = req.headers['x-edit-token'];
-          if (!editToken || typeof editToken !== 'string') {
-            return res.status(401).json({ error: 'Missing edit token' });
+          const emailSessionHeader = req.headers['x-email-session'] as string | undefined;
+          const hasTokenHeader = typeof editToken === 'string' && editToken.length > 0;
+          const hasNostr = authHeader?.startsWith('Nostr ');
+          const hasEmailSession = typeof emailSessionHeader === 'string' && emailSessionHeader.length > 0;
+
+          if (!hasTokenHeader && !hasNostr && !hasEmailSession) {
+            return res.status(401).json({ error: 'Missing credentials' });
           }
 
-          // Get metadata from .meta.json
-          const metadata = await getMetadata(feedId as string);
-          const providedHash = hashToken(editToken);
+          // Accept token, Nostr owner, or email-session owner (mirrors PUT).
+          let authorized = false;
 
-          // For legacy feeds without metadata, allow deletion with any token
-          // (can't verify, but feed is unusable anyway)
-          if (metadata) {
-            if (!timingSafeEqualHex(metadata.editTokenHash, providedHash)) {
-              return res.status(403).json({ error: 'Invalid edit token' });
+          if (hasTokenHeader) {
+            const providedHash = hashToken(editToken as string);
+            if (!metadata) {
+              // Legacy feed without metadata: can't verify, but it's unusable anyway.
+              authorized = true;
+            } else if (timingSafeEqualHex(metadata.editTokenHash, providedHash)) {
+              authorized = true;
             }
           }
+
+          if (!authorized && metadata?.ownerPubkey && hasNostr) {
+            const na = await parseFeedAuthHeader(authHeader);
+            if (na.valid && na.pubkey === metadata.ownerPubkey) {
+              authorized = true;
+            }
+          }
+
+          if (!authorized && emailSessionOwns(metadata ?? {}, emailSessionHeader)) {
+            authorized = true;
+          }
+
+          if (!authorized) {
+            return res.status(403).json({ error: 'Invalid credentials' });
+          }
+        }
+
+        // Drop the feed from its owner's account index (best-effort; email-claimed feeds only).
+        if (metadata?.ownerEmailHash) {
+          await removeFeedFromAccount(metadata.ownerEmailHash, feedId as string).catch(() => { /* best-effort */ });
         }
 
         // Get existing feed blob

--- a/api/hosted/[feedId].ts
+++ b/api/hosted/[feedId].ts
@@ -33,6 +33,27 @@ function emailSessionOwns(metadata: { ownerEmailHash?: string }, header: string 
   return auth.valid && auth.emailHash === metadata.ownerEmailHash;
 }
 
+/**
+ * Authorize a write (PUT/DELETE) against a feed that HAS metadata. Accepts, in order:
+ * a matching edit token, the linked Nostr owner, or the linked email owner. The legacy
+ * no-metadata path is handled by callers. Single source of the write-auth ladder so
+ * PUT and DELETE can't drift apart.
+ */
+async function isAuthorizedFeedWrite(
+  metadata: FeedMetadata,
+  creds: { editToken?: string | string[]; authHeader?: string; emailSessionHeader?: string }
+): Promise<boolean> {
+  const token = typeof creds.editToken === 'string' ? creds.editToken : undefined;
+  if (token && timingSafeEqualHex(metadata.editTokenHash, hashToken(token))) {
+    return true;
+  }
+  if (metadata.ownerPubkey && creds.authHeader?.startsWith('Nostr ')) {
+    const nostrAuth = await parseFeedAuthHeader(creds.authHeader);
+    if (nostrAuth.valid && nostrAuth.pubkey === metadata.ownerPubkey) return true;
+  }
+  return emailSessionOwns(metadata, creds.emailSessionHeader);
+}
+
 // Helper to fetch metadata from .meta.json blob
 async function getMetadata(feedId: string): Promise<FeedMetadata | null> {
   const metaPath = `feeds/${feedId}.meta.json`;
@@ -271,30 +292,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           existingPodcastIndexId = metadata.podcastIndexId;
           existingIsDraft = metadata.isDraft;
 
-          // Validate auth: accept token, Nostr owner, or email-session owner.
-          let isAuthorized = false;
-
-          // Try token auth first
-          if (editToken && typeof editToken === 'string') {
-            const providedHash = hashToken(editToken);
-            if (timingSafeEqualHex(storedHash, providedHash)) {
-              isAuthorized = true;
-            }
-          }
-
-          // Try Nostr auth if token didn't work and feed has owner
-          if (!isAuthorized && ownerPubkey && authHeader?.startsWith('Nostr ')) {
-            const nostrAuth = await parseFeedAuthHeader(authHeader);
-            if (nostrAuth.valid && nostrAuth.pubkey === ownerPubkey) {
-              isAuthorized = true;
-            }
-          }
-
-          // Try email-session auth if not yet authorized and feed has an email owner
-          if (!isAuthorized && emailSessionOwns(metadata, emailSessionHeader)) {
-            isAuthorized = true;
-          }
-
+          // Accept a matching edit token, the Nostr owner, or the email-session owner.
+          const isAuthorized = await isAuthorizedFeedWrite(metadata, { editToken, authHeader, emailSessionHeader });
           if (!isAuthorized) {
             return res.status(403).json({ error: 'Invalid credentials' });
           }
@@ -454,29 +453,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             return res.status(401).json({ error: 'Missing credentials' });
           }
 
-          // Accept token, Nostr owner, or email-session owner (mirrors PUT).
-          let authorized = false;
-
-          if (hasTokenHeader) {
-            const providedHash = hashToken(editToken as string);
-            if (!metadata) {
-              // Legacy feed without metadata: can't verify, but it's unusable anyway.
-              authorized = true;
-            } else if (timingSafeEqualHex(metadata.editTokenHash, providedHash)) {
-              authorized = true;
-            }
-          }
-
-          if (!authorized && metadata?.ownerPubkey && hasNostr) {
-            const na = await parseFeedAuthHeader(authHeader);
-            if (na.valid && na.pubkey === metadata.ownerPubkey) {
-              authorized = true;
-            }
-          }
-
-          if (!authorized && emailSessionOwns(metadata ?? {}, emailSessionHeader)) {
-            authorized = true;
-          }
+          // Legacy feeds without metadata can't be verified (unusable anyway) — any token deletes.
+          // Otherwise: matching token, Nostr owner, or email-session owner (mirrors PUT).
+          const authorized = metadata
+            ? await isAuthorizedFeedWrite(metadata, { editToken, authHeader, emailSessionHeader })
+            : hasTokenHeader;
 
           if (!authorized) {
             return res.status(403).json({ error: 'Invalid credentials' });

--- a/api/hosted/feedId-email-auth.test.ts
+++ b/api/hosted/feedId-email-auth.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockList = vi.fn();
+const mockPut = vi.fn();
+const mockDel = vi.fn();
+vi.mock('@vercel/blob', () => ({ list: mockList, put: mockPut, del: mockDel }));
+
+const mockAddFeed = vi.fn();
+const mockRemoveFeed = vi.fn();
+vi.mock('../_utils/accountStore.js', () => ({
+  addFeedToAccount: (...a: unknown[]) => mockAddFeed(...a),
+  removeFeedFromAccount: (...a: unknown[]) => mockRemoveFeed(...a)
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { hashToken } from '../_utils/feedUtils';
+import { signSession, emailHash } from '../_utils/emailAuth';
+
+const FEED = '11111111-2222-3333-4444-555555555555';
+const EMAIL = 'owner@example.com';
+const REAL_TOKEN = 'the-real-edit-token-aaaaaaaaaaaaaaaa';
+
+function meta(extra: Record<string, unknown> = {}) {
+  return {
+    editTokenHash: hashToken(REAL_TOKEN),
+    createdAt: '1',
+    title: 'My Feed',
+    ownerEmailHash: emailHash(EMAIL),
+    ...extra
+  };
+}
+
+function configureBlobs(metaObj: Record<string, unknown> | null) {
+  mockList.mockImplementation(({ prefix }: { prefix: string }) => {
+    if (prefix === `feeds/${FEED}.meta.json`) {
+      return Promise.resolve({ blobs: metaObj ? [{ pathname: `feeds/${FEED}.meta.json`, url: 'https://blob/meta' }] : [] });
+    }
+    if (prefix === `feeds/${FEED}.xml`) {
+      return Promise.resolve({ blobs: [{ pathname: `feeds/${FEED}.xml`, url: 'https://blob/xml' }] });
+    }
+    return Promise.resolve({ blobs: [] }); // backups, etc.
+  });
+  mockFetch.mockImplementation((url: string) => {
+    if (String(url).includes('meta')) {
+      return Promise.resolve({ text: async () => (metaObj ? JSON.stringify(metaObj) : ''), json: async () => metaObj ?? {} });
+    }
+    return Promise.resolve({ text: async () => '<rss>feed</rss>' });
+  });
+}
+
+function reqRes(method: string, opts: { headers?: Record<string, string>; body?: unknown } = {}) {
+  const req = { method, query: { feedId: FEED }, headers: opts.headers ?? {}, body: opts.body } as any;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+    setHeader: vi.fn().mockReturnThis(),
+    end: vi.fn().mockReturnThis()
+  } as any;
+  return { req, res };
+}
+
+describe('hosted [feedId] email-session auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MSP_EMAIL_HASH_KEY = 'test-hash-key-aaaaaaaaaaaaaaaaaaaa';
+    process.env.MSP_SESSION_SECRET = 'test-session-secret-bbbbbbbbbbbbbbbb';
+    mockPut.mockResolvedValue({});
+    mockDel.mockResolvedValue({});
+    mockAddFeed.mockResolvedValue(undefined);
+    mockRemoveFeed.mockResolvedValue(undefined);
+  });
+
+  it('PUT: authorizes the email owner with a valid session', async () => {
+    configureBlobs(meta());
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('PUT', {
+      headers: { 'x-email-session': `Bearer ${signSession(emailHash(EMAIL))}` },
+      body: { xml: '<rss>new</rss>', isDraft: true }
+    });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('PUT: rejects a session for a different email with 403', async () => {
+    configureBlobs(meta());
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('PUT', {
+      headers: { 'x-email-session': `Bearer ${signSession(emailHash('someone-else@example.com'))}` },
+      body: { xml: '<rss>new</rss>', isDraft: true }
+    });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('PUT: preserves ownerEmailHash in the written metadata', async () => {
+    configureBlobs(meta());
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('PUT', {
+      headers: { 'x-email-session': `Bearer ${signSession(emailHash(EMAIL))}` },
+      body: { xml: '<rss>new</rss>', isDraft: true }
+    });
+    await handler(req, res);
+    const metaWrite = mockPut.mock.calls.find(c => String(c[0]).endsWith('.meta.json'));
+    expect(metaWrite).toBeTruthy();
+    expect(JSON.parse(metaWrite![1]).ownerEmailHash).toBe(emailHash(EMAIL));
+  });
+
+  it('DELETE: authorizes the email owner and de-indexes the feed', async () => {
+    configureBlobs(meta());
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('DELETE', {
+      headers: { 'x-email-session': `Bearer ${signSession(emailHash(EMAIL))}` }
+    });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockRemoveFeed).toHaveBeenCalledWith(emailHash(EMAIL), FEED);
+  });
+
+  it('DELETE: rejects with 401 when no credentials are supplied', async () => {
+    configureBlobs(meta());
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('DELETE', { headers: {} });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('PATCH: links an email identity when given a valid token + session', async () => {
+    configureBlobs(meta({ ownerEmailHash: undefined }));
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('PATCH', {
+      headers: {
+        'x-edit-token': REAL_TOKEN,
+        'x-email-session': `Bearer ${signSession(emailHash(EMAIL))}`
+      }
+    });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockAddFeed).toHaveBeenCalledWith(emailHash(EMAIL), FEED);
+    const metaWrite = mockPut.mock.calls.find(c => String(c[0]).endsWith('.meta.json'));
+    expect(JSON.parse(metaWrite![1]).ownerEmailHash).toBe(emailHash(EMAIL));
+  });
+
+  it('PATCH: rejects a wrong edit token with 403', async () => {
+    configureBlobs(meta());
+    const { default: handler } = await import('./[feedId]');
+    const { req, res } = reqRes('PATCH', {
+      headers: {
+        'x-edit-token': 'wrong-token',
+        'x-email-session': `Bearer ${signSession(emailHash(EMAIL))}`
+      }
+    });
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -10,6 +10,8 @@ import {
 } from '../_utils/feedUtils.js';
 import { extractPodcastMedium } from '../_utils/xmlUtils.js';
 import { hydrateFeed } from '../_utils/feedHydrate.js';
+import { parseEmailAuthHeader } from '../_utils/emailAuth.js';
+import { addFeedToAccount } from '../_utils/accountStore.js';
 
 // Generate a secure edit token
 function generateEditToken(): string {
@@ -125,6 +127,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
+    // Check for an email session - if provided, set the email owner immediately
+    const emailSessionHeader = req.headers['x-email-session'] as string | undefined;
+    let ownerEmailHash: string | undefined;
+    let emailLinkedAt: string | undefined;
+
+    if (emailSessionHeader) {
+      const emailAuth = parseEmailAuthHeader(emailSessionHeader);
+      if (emailAuth.valid && emailAuth.emailHash) {
+        ownerEmailHash = emailAuth.emailHash;
+        emailLinkedAt = Date.now().toString();
+      }
+    }
+
     // Store feed XML in Vercel Blob
     // allowOverwrite handles orphaned blobs from incomplete deletions
     const blob = await put(`feeds/${feedId}.xml`, xml, {
@@ -150,6 +165,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       title: (typeof title === 'string' ? title : 'Untitled Feed').slice(0, 200),
       ownerPubkey,
       linkedAt,
+      ownerEmailHash,
+      emailLinkedAt,
       podcastIndexId,
       ...(isDraft === true && { isDraft: true })
     }), {
@@ -158,6 +175,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       addRandomSuffix: false,
       allowOverwrite: true
     });
+
+    // Index the new feed to the email account so it appears in "My Feeds"
+    if (ownerEmailHash) {
+      await addFeedToAccount(ownerEmailHash, feedId).catch(() => { /* best-effort */ });
+    }
 
     return res.status(201).json({
       feedId,

--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -52,7 +52,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
       // If not admin, filter to only show user's own feeds
       if (!isAdmin && userPubkey) {
-        feeds = feeds.filter((feed: { ownerPubkey?: string }) => feed.ownerPubkey === userPubkey);
+        feeds = feeds.filter((feed) => feed.ownerPubkey === userPubkey);
       }
 
       return res.status(200).json({ feeds, count: feeds.length });

--- a/api/hosted/index.ts
+++ b/api/hosted/index.ts
@@ -4,12 +4,12 @@ import { randomBytes } from 'crypto';
 import { parseAuthHeader, parseFeedAuthHeader } from '../_utils/adminAuth.js';
 import {
   notifyPodcastIndex,
-  lookupPodcastIndexId,
   getBaseUrl,
   hashToken,
   isValidFeedId
 } from '../_utils/feedUtils.js';
 import { extractPodcastMedium } from '../_utils/xmlUtils.js';
+import { hydrateFeed } from '../_utils/feedHydrate.js';
 
 // Generate a secure edit token
 function generateEditToken(): string {
@@ -41,53 +41,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const xmlBlobs = blobs.filter(b => b.pathname.endsWith('.xml') && !b.pathname.includes('.backup.'));
 
       let feeds = await Promise.all(
-        metaBlobs.map(async (blob) => {
-          const response = await fetch(blob.url);
-          const text = await response.text();
-          const meta = text ? JSON.parse(text) : {};
+        metaBlobs.map((blob) => {
           const feedId = blob.pathname.replace('feeds/', '').replace('.meta.json', '');
-
-          // Try to extract author and medium from the XML feed
-          let author: string | undefined;
-          let medium: string | undefined;
           const xmlBlob = xmlBlobs.find(b => b.pathname === `feeds/${feedId}.xml`);
-          if (xmlBlob) {
-            try {
-              const xmlResponse = await fetch(xmlBlob.url);
-              const xml = await xmlResponse.text();
-              // Extract itunes:author using regex
-              const authorMatch = xml.match(/<itunes:author>([^<]+)<\/itunes:author>/);
-              if (authorMatch) {
-                author = authorMatch[1];
-              }
-              const extractedMedium = extractPodcastMedium(xml);
-              if (extractedMedium) {
-                medium = extractedMedium;
-              }
-            } catch {
-              // Ignore errors extracting metadata
-            }
-          }
-
-          // Look up PI ID if missing and update metadata in background
-          let podcastIndexId = meta.podcastIndexId;
-          if (!podcastIndexId) {
-            // feedId is the podcast GUID, use it to lookup on PI
-            podcastIndexId = await lookupPodcastIndexId(feedId);
-            if (podcastIndexId) {
-              // Update metadata with PI ID (don't await - fire and forget)
-              put(`feeds/${feedId}.meta.json`, JSON.stringify({
-                ...meta,
-                podcastIndexId
-              }), {
-                access: 'public',
-                contentType: 'application/json',
-                addRandomSuffix: false
-              }).catch(err => console.warn('Failed to update metadata with PI ID:', err));
-            }
-          }
-
-          return { feedId, author, medium, ...meta, podcastIndexId };
+          return hydrateFeed(feedId, blob.url, xmlBlob?.url);
         })
       );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { NewFeedChoiceModal } from './components/modals/NewFeedChoiceModal';
 import { Editor } from './components/Editor/Editor';
 import { PublisherEditor } from './components/Editor/PublisherEditor';
 import { AdminPage } from './components/admin/AdminPage';
+import { VerifyMagicLink } from './pages/VerifyMagicLink';
 import type { Album } from './types/feed';
 import mspLogo from './assets/msp-logo.png';
 import './App.css';
@@ -386,6 +387,15 @@ function AppContent() {
 // Main App
 function App() {
   const isAdminRoute = window.location.pathname === '/admin';
+  const isVerifyRoute = window.location.pathname === '/auth/verify';
+
+  if (isVerifyRoute) {
+    return (
+      <ThemeProvider>
+        <VerifyMagicLink />
+      </ThemeProvider>
+    );
+  }
 
   if (isAdminRoute) {
     return (

--- a/src/components/auth/EmailLoginModal.tsx
+++ b/src/components/auth/EmailLoginModal.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { ModalWrapper } from '../modals/ModalWrapper';
+import { requestMagicLink } from '../../utils/emailSession';
+
+interface EmailLoginModalProps {
+  onClose: () => void;
+  // When present, the link claims this feed (proves ownership with the edit token)
+  // instead of a plain sign-in.
+  claim?: { feedId: string; editToken: string; feedTitle?: string };
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function EmailLoginModal({ onClose, claim }: EmailLoginModalProps) {
+  const [email, setEmail] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isClaim = Boolean(claim);
+  const emailValid = EMAIL_RE.test(email.trim());
+
+  const handleSubmit = async () => {
+    if (!emailValid) {
+      setError('Please enter a valid email address');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await requestMagicLink(email.trim(), isClaim
+        ? { purpose: 'claim', feedId: claim!.feedId, editToken: claim!.editToken }
+        : { purpose: 'login' });
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send link');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <ModalWrapper
+      isOpen={true}
+      onClose={onClose}
+      title={isClaim ? 'Claim feed with email' : 'Sign in with email'}
+      footer={
+        <div style={{ display: 'flex', gap: '12px', width: '100%' }}>
+          {!sent && (
+            <button
+              className="btn btn-primary"
+              onClick={handleSubmit}
+              disabled={submitting || !emailValid}
+            >
+              {submitting ? 'Sending…' : 'Send magic link'}
+            </button>
+          )}
+          <div style={{ flex: 1 }} />
+          <button className="btn btn-secondary" onClick={onClose}>
+            {sent ? 'Done' : 'Cancel'}
+          </button>
+        </div>
+      }
+    >
+      {sent ? (
+        <p style={{ color: 'var(--text-secondary)', fontSize: '0.9rem' }}>
+          Check your inbox at <strong>{email.trim()}</strong>. Click the link to{' '}
+          {isClaim ? 'finish claiming your feed' : 'sign in'}. The link expires shortly and can be used once.
+        </p>
+      ) : (
+        <>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '12px' }}>
+            {isClaim
+              ? <>Attach your email to {claim?.feedTitle ? <strong>{claim.feedTitle}</strong> : 'this feed'} so you can manage it from any device — no token to keep. We'll email you a link to confirm.</>
+              : 'Manage your MSP-hosted feeds from any device. We’ll email you a one-time sign-in link — no password to remember.'}
+          </p>
+          <div style={{ marginBottom: '12px' }}>
+            <label style={{ display: 'block', marginBottom: '4px', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+              Email
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && emailValid) handleSubmit(); }}
+              placeholder="you@example.com"
+              autoFocus
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                borderRadius: '4px',
+                border: '1px solid var(--border-color)',
+                backgroundColor: 'var(--bg-secondary)',
+                color: 'var(--text-primary)',
+                fontSize: '0.875rem'
+              }}
+            />
+          </div>
+        </>
+      )}
+      {error && (
+        <div style={{ color: 'var(--error, #ef4444)', marginTop: '12px', fontSize: '0.875rem' }}>
+          {error}
+        </div>
+      )}
+    </ModalWrapper>
+  );
+}

--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -3,7 +3,9 @@ import { fetchFeedFromUrl } from '../../utils/xmlParser';
 import { loadAlbumsFromNostr, loadAlbumByDTag, fetchNostrMusicTracks, groupTracksByAlbum } from '../../utils/nostrSync';
 import { convertNostrMusicToAlbum, parseNostrEventJson } from '../../utils/nostrMusicConverter';
 import { type HostedFeedInfo, buildHostedUrl } from '../../utils/hostedFeed';
-import { fetchAdminFeeds } from '../../utils/adminAuth';
+import { fetchAdminFeeds, fetchEmailFeeds } from '../../utils/adminAuth';
+import { isEmailLoggedIn, getEmailSession } from '../../utils/emailSession';
+import { EmailLoginModal } from '../auth/EmailLoginModal';
 import { pendingHostedStorage } from '../../utils/storage';
 import { formatTimestamp } from '../../utils/dateUtils';
 import { checkSignerConnection } from '../../utils/nostrSigner';
@@ -21,6 +23,7 @@ interface HostedFeedListItem {
   createdAt?: string;
   lastUpdated?: string;
   ownerPubkey?: string;
+  ownerEmailHash?: string;
 }
 
 interface ImportModalProps {
@@ -50,6 +53,7 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
   const [showHelp, setShowHelp] = useState(false);
   const [hostedFeeds, setHostedFeeds] = useState<HostedFeedListItem[]>([]);
   const [loadingHostedFeeds, setLoadingHostedFeeds] = useState(false);
+  const [showEmailLogin, setShowEmailLogin] = useState(false);
 
   // Reset mode if the current selection is an experimental option that just got hidden
   useEffect(() => {
@@ -79,27 +83,34 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
     }
   };
 
+  const canListFeeds = isLoggedIn || isEmailLoggedIn();
+
   const fetchHostedFeeds = async () => {
-    if (!isLoggedIn || !nostrState.user?.pubkey) return;
+    if (!canListFeeds) return;
 
     setLoadingHostedFeeds(true);
     setError('');
 
-    const health = await checkSignerConnection();
-    if (!health.connected) {
-      setError(health.error ?? 'Nostr signer is not connected.');
-      setLoadingHostedFeeds(false);
-      return;
-    }
-
     try {
-      const result = await fetchAdminFeeds();
-      // Filter to only show feeds owned by the current user
-      const myFeeds = result.feeds.filter(
-        (f: HostedFeedListItem) => f.ownerPubkey === nostrState.user?.pubkey
-      );
-      setHostedFeeds(myFeeds);
-      if (myFeeds.length === 0) {
+      let feeds: HostedFeedListItem[];
+      if (isLoggedIn && nostrState.user?.pubkey) {
+        const health = await checkSignerConnection();
+        if (!health.connected) {
+          setError(health.error ?? 'Nostr signer is not connected.');
+          return;
+        }
+        const result = await fetchAdminFeeds();
+        // Filter to only show feeds owned by the current user
+        feeds = result.feeds.filter(
+          (f: HostedFeedListItem) => f.ownerPubkey === nostrState.user?.pubkey
+        );
+      } else {
+        // Email account: the server already scopes the list to this account.
+        const result = await fetchEmailFeeds();
+        feeds = result.feeds;
+      }
+      setHostedFeeds(feeds);
+      if (feeds.length === 0) {
         setError('No hosted feeds found for your account');
       }
     } catch (err) {
@@ -235,15 +246,22 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
       }
       const xml = await response.text();
 
-      // Store feed info as pending (linked to Nostr, no token needed)
+      // Store feed info as pending (owned via Nostr or email, no token needed)
       const newInfo: HostedFeedInfo = {
         feedId: feed.feedId,
-        editToken: '', // No token needed - linked to Nostr
+        editToken: '', // No token needed - owned via linked identity
         createdAt: Date.now(),
-        lastUpdated: Date.now(),
-        ownerPubkey: feed.ownerPubkey,
-        linkedAt: Date.now()
+        lastUpdated: Date.now()
       };
+      if (feed.ownerPubkey) {
+        newInfo.ownerPubkey = feed.ownerPubkey;
+        newInfo.linkedAt = Date.now();
+      }
+      const emailHash = feed.ownerEmailHash ?? getEmailSession()?.emailHash;
+      if (emailHash) {
+        newInfo.ownerEmailHash = emailHash;
+        newInfo.emailLinkedAt = Date.now();
+      }
       pendingHostedStorage.save(newInfo);
 
       // Pass the hosted URL as source URL
@@ -333,7 +351,7 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
               </button>
             ) : mode === 'hosted' ? (
               <>
-                {isLoggedIn && (
+                {canListFeeds && (
                   <button className="btn btn-secondary" onClick={fetchHostedFeeds} disabled={loadingHostedFeeds}>
                     {loadingHostedFeeds ? 'Loading...' : 'Refresh'}
                   </button>
@@ -375,7 +393,7 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                 setMode(newMode);
                 if (newMode === 'nostr') fetchSavedAlbums();
                 if (newMode === 'nostrMusic') fetchMusicTracks();
-                if (newMode === 'hosted' && isLoggedIn) fetchHostedFeeds();
+                if (newMode === 'hosted' && canListFeeds) fetchHostedFeeds();
               }}
             >
               <option value="file">Upload File</option>
@@ -535,8 +553,8 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
             </div>
           ) : mode === 'hosted' ? (
             <div className="form-group">
-              {/* Show user's hosted feeds if logged in */}
-              {isLoggedIn && (
+              {/* Show user's hosted feeds if logged in (Nostr or email) */}
+              {canListFeeds && (
                 <div style={{ marginBottom: '16px' }}>
                   <label className="form-label">My Hosted Feeds</label>
                   <select
@@ -577,10 +595,19 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                 </div>
               )}
 
-              {!isLoggedIn && (
-                <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '12px' }}>
-                  Import a feed hosted on MSP. Upload your backup file or enter details manually.
-                </p>
+              {!canListFeeds && (
+                <div style={{ marginBottom: '12px' }}>
+                  <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '8px' }}>
+                    Import a feed hosted on MSP. Upload your backup file or enter details manually.
+                  </p>
+                  <button
+                    className="btn btn-secondary"
+                    style={{ fontSize: '0.75rem' }}
+                    onClick={() => setShowEmailLogin(true)}
+                  >
+                    Sign in with email to see your feeds
+                  </button>
+                </div>
               )}
 
               {/* Upload backup file */}
@@ -706,6 +733,10 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                 {showExperimental && <li><strong>From Nostr 🧪</strong> - Load your previously saved albums from Nostr (requires login)</li>}
               </ul>
             </ModalWrapper>
+      )}
+
+      {showEmailLogin && (
+        <EmailLoginModal onClose={() => setShowEmailLogin(false)} />
       )}
     </>
   );

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -1241,36 +1241,50 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                       </p>
                     </div>
                   )}
-                  {/* Link Nostr button for existing feeds without Nostr link */}
-                  {isLoggedIn && hostedInfo && !isNostrLinked && (
+                  {/* Token-owned feed (e.g. just restored): offer to switch it to an account so the token isn't needed. */}
+                  {hostedInfo && !isNostrLinked && !isEmailLinked && (
                     <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid var(--border-color)' }}>
-                      <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: '8px' }}>
-                        Link your Nostr identity to manage this feed without needing the token.
+                      <p style={{ fontSize: '0.8rem', fontWeight: 600, color: 'var(--text-primary)', marginBottom: '4px' }}>
+                        Switch this feed to your account
                       </p>
-                      <button
-                        className="btn btn-secondary"
-                        style={{ fontSize: '0.75rem' }}
-                        onClick={handleLinkNostr}
-                        disabled={linkingNostr}
-                      >
-                        {linkingNostr ? 'Linking...' : 'Link Nostr Identity'}
-                      </button>
+                      <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: '8px' }}>
+                        Link your email or Nostr so you can manage this feed from any device — no token to keep safe.
+                      </p>
+                      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                        <button
+                          className="btn btn-secondary"
+                          style={{ fontSize: '0.75rem' }}
+                          onClick={handleLinkEmail}
+                          disabled={linkingEmail}
+                        >
+                          {linkingEmail ? 'Linking…' : (isEmailLoggedIn() ? 'Claim with Email' : 'Claim with Email…')}
+                        </button>
+                        {isLoggedIn ? (
+                          <button
+                            className="btn btn-secondary"
+                            style={{ fontSize: '0.75rem' }}
+                            onClick={handleLinkNostr}
+                            disabled={linkingNostr}
+                          >
+                            {linkingNostr ? 'Linking…' : 'Link Nostr Identity'}
+                          </button>
+                        ) : (
+                          <button
+                            className="btn btn-secondary"
+                            style={{ fontSize: '0.75rem' }}
+                            onClick={() => setShowNostrConnect(true)}
+                          >
+                            Sign in with Nostr
+                          </button>
+                        )}
+                      </div>
                     </div>
                   )}
-                  {/* Claim with email for existing feeds not yet email-linked */}
-                  {hostedInfo && !isEmailLinked && (
+                  {isNostrLinked && (
                     <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid var(--border-color)' }}>
-                      <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: '8px' }}>
-                        Claim this feed with your email to manage it from any device — no token to keep safe.
+                      <p style={{ fontSize: '0.75rem', color: 'var(--success, #10b981)', margin: 0 }}>
+                        🔑 Linked to your Nostr identity — manageable from any device.
                       </p>
-                      <button
-                        className="btn btn-secondary"
-                        style={{ fontSize: '0.75rem' }}
-                        onClick={handleLinkEmail}
-                        disabled={linkingEmail}
-                      >
-                        {linkingEmail ? 'Linking…' : (isEmailLoggedIn() ? 'Claim with Email' : 'Claim with Email…')}
-                      </button>
                     </div>
                   )}
                   {isEmailLinked && (

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -14,7 +14,6 @@ import {
   createHostedFeed,
   updateHostedFeed,
   buildHostedUrl,
-  downloadHostedFeedBackup,
   generateEditToken,
   createHostedFeedWithNostr,
   updateHostedFeedWithNostr,
@@ -27,6 +26,7 @@ import {
 import { albumStorage, videoStorage, publisherStorage, pendingHostedStorage } from '../../utils/storage';
 import { getEmailSession, isEmailLoggedIn } from '../../utils/emailSession';
 import { EmailLoginModal } from '../auth/EmailLoginModal';
+import { NostrConnectModal } from './NostrConnectModal';
 import { useNostr } from '../../store/nostrStore';
 import { useExperimental } from '../../store/experimentalStore';
 import { checkSignerConnection } from '../../utils/nostrSigner';
@@ -112,6 +112,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   const [linkingNostr, setLinkingNostr] = useState(false);
   const [linkingEmail, setLinkingEmail] = useState(false);
   const [emailModal, setEmailModal] = useState<null | { mode: 'login' } | { mode: 'claim' }>(null);
+  const [showNostrConnect, setShowNostrConnect] = useState(false);
   const [podcastIndexPending, setPodcastIndexPending] = useState(false); // True when PI notified but not yet indexed
   const [isDraft, setIsDraft] = useState(false);
   const nsiteSiteId = defaultSiteId(currentFeedGuid);
@@ -151,9 +152,9 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   // Helper to determine if button should be disabled
   const isButtonDisabled = () => {
     if (loading) return true;
-    // Email-logged-in users don't need to babysit a token (email is their recovery),
-    // so the "I saved my token" gate only applies to anonymous, non-email hosting.
-    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !tokenAcknowledged && !isEmailLoggedIn()) return true;
+    // Signed-in users (email or Nostr) don't need to babysit a token — their identity
+    // is the recovery — so the "I saved my token" gate only applies to anonymous hosting.
+    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !tokenAcknowledged && !isEmailLoggedIn() && !isLoggedIn) return true;
     if (mode === 'podcastIndex' && (!podcastIndexSubmitUrl.trim() || !!podcastIndexUrlError)) return true;
     return false;
   };
@@ -1091,9 +1092,11 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                   ? 'Your feed is already hosted. Click Save to update it with your latest changes.'
                   : legacyHostedInfo
                     ? 'Your feed URL will be migrated to match the Podcast GUID. Both old and new URLs will be updated.'
-                    : pendingToken
-                      ? 'Save your edit token before uploading!'
-                      : 'Host your RSS feed on MSP. No account required - just save your edit token!'}
+                    : isEmailLoggedIn()
+                      ? 'Host your RSS feed on MSP — it will be owned by your email account, manageable from any device.'
+                      : isLoggedIn
+                        ? 'Host your RSS feed on MSP — it will be linked to your Nostr identity, manageable from any device.'
+                        : 'Host your RSS feed on MSP — get a permanent URL for any podcast app.'}
               </p>
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '0.875rem', marginTop: '12px' }}>
                 <input
@@ -1117,83 +1120,51 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                   </p>
                 </div>
               )}
-              {pendingToken && !hostedInfo && !legacyHostedInfo && (
-                <div style={{ marginTop: '16px', padding: '12px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '8px', border: '1px solid var(--warning, #f59e0b)' }}>
-                  <label style={{ display: 'block', marginBottom: '4px', fontSize: '0.875rem', fontWeight: 600, color: 'var(--warning, #f59e0b)' }}>
-                    {isLoggedIn ? 'Backup Token (save this!)' : 'Edit Token (save this!)'}
-                  </label>
-                  <input
-                    type="text"
-                    value={pendingToken}
-                    readOnly
-                    onClick={(e) => (e.target as HTMLInputElement).select()}
-                    style={{
-                      width: '100%',
-                      padding: '8px 12px',
-                      borderRadius: '4px',
-                      border: '1px solid var(--warning, #f59e0b)',
-                      backgroundColor: 'var(--bg-secondary)',
-                      color: 'var(--text-primary)',
-                      fontSize: '0.75rem',
-                      fontFamily: 'monospace'
-                    }}
-                  />
-                  <p style={{ color: 'var(--warning, #f59e0b)', fontSize: '0.75rem', marginTop: '8px', marginBottom: '12px' }}>
-                    You need this token to edit your feed later. Save it somewhere safe!
+              {/* Logged-out users must sign in to host a NEW feed. Tokens are no longer offered for new feeds. */}
+              {!hostedInfo && !legacyHostedInfo && !isEmailLoggedIn() && !isLoggedIn && !showRestore && (
+                <div style={{ marginTop: '16px', padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
+                  <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
+                    Sign in to host your feed
                   </p>
-                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
+                  <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
+                    Sign in with your email or Nostr so this feed is owned by your account — manage it from any device, nothing to keep safe.
+                  </p>
+                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
                     <button
-                      className="btn btn-secondary"
-                      onClick={() => {
-                        navigator.clipboard.writeText(pendingToken);
-                        setMessage({ type: 'success', text: 'Token copied to clipboard' });
-                      }}
+                      className="btn btn-primary"
+                      style={{ fontSize: '0.8rem' }}
+                      onClick={() => setEmailModal({ mode: 'login' })}
                     >
-                      Copy Token
+                      Sign in with email
                     </button>
                     <button
                       className="btn btn-secondary"
-                      onClick={() => {
-                        downloadHostedFeedBackup(currentFeedGuid, pendingToken, currentFeedTitle, currentFeedGuid);
-                        setMessage({ type: 'success', text: 'Backup file downloaded' });
-                      }}
+                      style={{ fontSize: '0.8rem' }}
+                      onClick={() => setShowNostrConnect(true)}
                     >
-                      Download Backup
+                      Sign in with Nostr
                     </button>
                   </div>
-                  <label style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '8px',
-                    cursor: 'pointer',
-                    fontSize: '0.75rem',
-                    color: 'var(--text-primary)',
-                    padding: '8px',
-                    backgroundColor: tokenAcknowledged ? 'rgba(16, 185, 129, 0.1)' : 'transparent',
-                    borderRadius: '4px',
-                    border: tokenAcknowledged ? '1px solid var(--success, #10b981)' : '1px solid var(--border-color)'
-                  }}>
-                    <input
-                      type="checkbox"
-                      checked={tokenAcknowledged}
-                      onChange={(e) => setTokenAcknowledged(e.target.checked)}
-                      style={{ width: '16px', height: '16px' }}
-                    />
-                    <span>I have saved my edit token</span>
-                  </label>
                   <button
-                    className="btn btn-secondary"
-                    style={{ fontSize: '0.75rem', padding: '6px 12px', marginTop: '12px', width: '100%' }}
-                    onClick={() => {
-                      setPendingToken(null);
-                      setTokenAcknowledged(false);
-                      setShowRestore(true);
-                    }}
+                    style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', fontSize: '0.7rem', textDecoration: 'underline', cursor: 'pointer', marginTop: '10px', padding: 0 }}
+                    onClick={() => { setPendingToken(null); setTokenAcknowledged(false); setShowRestore(true); }}
                   >
-                    Already have a token? Restore existing feed
+                    Already have a feed with an edit token? Restore it
                   </button>
                 </div>
               )}
+              {/* Calm "owned by your account" note for signed-in users — no token to manage. */}
+              {pendingToken && !hostedInfo && !legacyHostedInfo && (isEmailLoggedIn() || isLoggedIn) && (
+                <div style={{ marginTop: '16px', padding: '12px', backgroundColor: 'rgba(16, 185, 129, 0.08)', borderRadius: '8px', border: '1px solid var(--success, #10b981)' }}>
+                  <p style={{ fontSize: '0.85rem', color: 'var(--success, #10b981)', fontWeight: 600, margin: 0 }}>
+                    {isEmailLoggedIn() ? '✉️ This feed will be owned by your email account.' : '🔑 This feed will be linked to your Nostr identity.'}
+                  </p>
+                  <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginTop: '6px', marginBottom: 0 }}>
+                    You can manage it from any device — nothing to keep safe.
+                  </p>
+                </div>
+              )}
+              {/* New feeds no longer show an edit-token panel — a signed-in identity (email/Nostr) owns the feed. */}
               {hostedUrl && (
                 <div style={{ marginTop: '16px', padding: '12px', backgroundColor: 'var(--bg-tertiary)', borderRadius: '8px', border: '1px solid var(--success)' }}>
                   <label style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px', fontSize: '0.875rem', fontWeight: 600, color: 'var(--success)' }}>
@@ -1580,6 +1551,9 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
             ? { feedId: hostedInfo.feedId, editToken: hostedInfo.editToken, feedTitle: currentFeedTitle }
             : undefined}
         />
+      )}
+      {showNostrConnect && (
+        <NostrConnectModal onClose={() => setShowNostrConnect(false)} />
       )}
     </>
   );

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -19,9 +19,14 @@ import {
   createHostedFeedWithNostr,
   updateHostedFeedWithNostr,
   linkNostrToFeed,
+  createHostedFeedWithEmail,
+  updateHostedFeedWithEmail,
+  linkEmailToFeed,
   type HostedFeedInfo
 } from '../../utils/hostedFeed';
 import { albumStorage, videoStorage, publisherStorage, pendingHostedStorage } from '../../utils/storage';
+import { getEmailSession, isEmailLoggedIn } from '../../utils/emailSession';
+import { EmailLoginModal } from '../auth/EmailLoginModal';
 import { useNostr } from '../../store/nostrStore';
 import { useExperimental } from '../../store/experimentalStore';
 import { checkSignerConnection } from '../../utils/nostrSigner';
@@ -105,6 +110,8 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   const [pendingToken, setPendingToken] = useState<string | null>(null);
   const [tokenAcknowledged, setTokenAcknowledged] = useState(false);
   const [linkingNostr, setLinkingNostr] = useState(false);
+  const [linkingEmail, setLinkingEmail] = useState(false);
+  const [emailModal, setEmailModal] = useState<null | { mode: 'login' } | { mode: 'claim' }>(null);
   const [podcastIndexPending, setPodcastIndexPending] = useState(false); // True when PI notified but not yet indexed
   const [isDraft, setIsDraft] = useState(false);
   const nsiteSiteId = defaultSiteId(currentFeedGuid);
@@ -117,6 +124,10 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
 
   // Check if feed is linked to current user's Nostr identity
   const isNostrLinked = hostedInfo?.ownerPubkey && nostrState.user?.pubkey === hostedInfo.ownerPubkey;
+
+  // Check if feed is claimed by the current email account
+  const emailSession = getEmailSession();
+  const isEmailLinked = !!(hostedInfo?.ownerEmailHash && emailSession?.emailHash === hostedInfo.ownerEmailHash);
 
   // Helper to get button text based on mode and loading state
   const getButtonText = () => {
@@ -140,7 +151,9 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   // Helper to determine if button should be disabled
   const isButtonDisabled = () => {
     if (loading) return true;
-    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !tokenAcknowledged) return true;
+    // Email-logged-in users don't need to babysit a token (email is their recovery),
+    // so the "I saved my token" gate only applies to anonymous, non-email hosting.
+    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !tokenAcknowledged && !isEmailLoggedIn()) return true;
     if (mode === 'podcastIndex' && (!podcastIndexSubmitUrl.trim() || !!podcastIndexUrlError)) return true;
     return false;
   };
@@ -527,10 +540,12 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
           }
 
           if (hostedInfo) {
-            // Update existing feed - use Nostr auth if linked, otherwise token
+            // Update existing feed - prefer Nostr, then email session, else token
             let updateResult;
             if (isNostrLinked) {
               updateResult = await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
+            } else if (isEmailLinked) {
+              updateResult = await updateHostedFeedWithEmail(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
             } else {
               updateResult = await updateHostedFeed(hostedInfo.feedId, hostedInfo.editToken, hostedXml, currentFeedTitle, isDraft);
             }
@@ -558,6 +573,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
             let hostedResult;
             let newInfo: HostedFeedInfo;
             const shouldLinkNostr = isLoggedIn && nostrState.user?.pubkey;
+            const shouldLinkEmail = !shouldLinkNostr && isEmailLoggedIn();
             if (shouldLinkNostr) {
               hostedResult = await createHostedFeedWithNostr(hostedXml, currentFeedTitle, currentFeedGuid, tokenToUse, isDraft);
               newInfo = {
@@ -567,6 +583,17 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                 lastUpdated: Date.now(),
                 ownerPubkey: nostrState.user!.pubkey,
                 linkedAt: Date.now(),
+                ...(hostedResult.isDraft && { isDraft: true })
+              };
+            } else if (shouldLinkEmail) {
+              hostedResult = await createHostedFeedWithEmail(hostedXml, currentFeedTitle, currentFeedGuid, tokenToUse, isDraft);
+              newInfo = {
+                feedId: hostedResult.feedId,
+                editToken: tokenToUse,
+                createdAt: Date.now(),
+                lastUpdated: Date.now(),
+                ownerEmailHash: emailSession?.emailHash,
+                emailLinkedAt: Date.now(),
                 ...(hostedResult.isDraft && { isDraft: true })
               };
             } else {
@@ -592,7 +619,9 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
               // Build success message with PI result
               let successMsg = legacyHostedInfo
                 ? 'Feed migrated to new URL and legacy URL updated!'
-                : (shouldLinkNostr ? 'Feed created and linked to your Nostr identity!' : 'Feed created!');
+                : (shouldLinkNostr
+                    ? 'Feed created and linked to your Nostr identity!'
+                    : (shouldLinkEmail ? 'Feed created and linked to your email!' : 'Feed created!'));
 
               if (hostedResult.podcastIndexId) {
                 setPodcastIndexPending(true);
@@ -679,6 +708,36 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
       setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Failed to link Nostr identity' });
     } finally {
       setLinkingNostr(false);
+    }
+  };
+
+  // Claim an existing feed with email. If already signed in with email, link directly;
+  // otherwise open the email modal in claim mode (sends a confirmation link).
+  const handleLinkEmail = async () => {
+    if (!hostedInfo) return;
+
+    if (!isEmailLoggedIn()) {
+      setEmailModal({ mode: 'claim' });
+      return;
+    }
+
+    setLinkingEmail(true);
+    setMessage(null);
+    try {
+      await linkEmailToFeed(hostedInfo.feedId, hostedInfo.editToken);
+      const session = getEmailSession();
+      const updatedInfo = {
+        ...hostedInfo,
+        ownerEmailHash: session?.emailHash,
+        emailLinkedAt: Date.now()
+      };
+      saveHostedFeedInfo(currentFeedGuid, updatedInfo);
+      setHostedInfo(updatedInfo);
+      setMessage({ type: 'success', text: 'Email linked! You can manage this feed from any device.' });
+    } catch (err) {
+      setMessage({ type: 'error', text: err instanceof Error ? err.message : 'Failed to link email' });
+    } finally {
+      setLinkingEmail(false);
     }
   };
 
@@ -1227,6 +1286,29 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                       </button>
                     </div>
                   )}
+                  {/* Claim with email for existing feeds not yet email-linked */}
+                  {hostedInfo && !isEmailLinked && (
+                    <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid var(--border-color)' }}>
+                      <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', marginBottom: '8px' }}>
+                        Claim this feed with your email to manage it from any device — no token to keep safe.
+                      </p>
+                      <button
+                        className="btn btn-secondary"
+                        style={{ fontSize: '0.75rem' }}
+                        onClick={handleLinkEmail}
+                        disabled={linkingEmail}
+                      >
+                        {linkingEmail ? 'Linking…' : (isEmailLoggedIn() ? 'Claim with Email' : 'Claim with Email…')}
+                      </button>
+                    </div>
+                  )}
+                  {isEmailLinked && (
+                    <div style={{ marginTop: '12px', paddingTop: '12px', borderTop: '1px solid var(--border-color)' }}>
+                      <p style={{ fontSize: '0.75rem', color: 'var(--success, #10b981)', margin: 0 }}>
+                        ✉️ Claimed with your email — manageable from any device.
+                      </p>
+                    </div>
+                  )}
                 </div>
               )}
               {!hostedInfo && !pendingToken && !legacyHostedInfo && (
@@ -1490,6 +1572,14 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                 {showExperimental && <li><strong>Publish RSS feed to nsite 🧪</strong> - Uploads the RSS file to a Blossom server and publishes an nsite site manifest (NIP-5A). Reachable as a permanent web URL through any nsite gateway. Subscribable in podcast apps.</li>}
               </ul>
             </ModalWrapper>
+      )}
+      {emailModal && (
+        <EmailLoginModal
+          onClose={() => setEmailModal(null)}
+          claim={emailModal.mode === 'claim' && hostedInfo
+            ? { feedId: hostedInfo.feedId, editToken: hostedInfo.editToken, feedTitle: currentFeedTitle }
+            : undefined}
+        />
       )}
     </>
   );

--- a/src/pages/VerifyMagicLink.tsx
+++ b/src/pages/VerifyMagicLink.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { verifyMagicLink } from '../utils/emailSession';
+
+type Status = 'verifying' | 'success' | 'error';
+
+/**
+ * Full-page handler for the emailed magic link (/auth/verify?token=...).
+ * Redeems the token, stores the session, then sends the user into the app.
+ */
+export function VerifyMagicLink() {
+  const token = useMemo(() => new URLSearchParams(window.location.search).get('token'), []);
+  // Derive the no-token error state up-front so the effect never sets state synchronously.
+  const [status, setStatus] = useState<Status>(token ? 'verifying' : 'error');
+  const [error, setError] = useState<string | null>(token ? null : 'This link is missing its token.');
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (!token || ran.current) return; // guard against StrictMode double-invoke (token is single-use)
+    ran.current = true;
+
+    verifyMagicLink(token)
+      .then(() => setStatus('success'))
+      .catch((err) => {
+        setStatus('error');
+        setError(err instanceof Error ? err.message : 'Invalid or expired link');
+      });
+  }, [token]);
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'var(--bg-primary)',
+      color: 'var(--text-primary)',
+      padding: '24px'
+    }}>
+      <div style={{
+        maxWidth: '420px',
+        textAlign: 'center',
+        background: 'var(--bg-secondary)',
+        border: '1px solid var(--border-color)',
+        borderRadius: '12px',
+        padding: '32px'
+      }}>
+        {status === 'verifying' && (
+          <>
+            <h2 style={{ marginTop: 0 }}>Signing you in…</h2>
+            <p style={{ color: 'var(--text-secondary)' }}>Verifying your link.</p>
+          </>
+        )}
+        {status === 'success' && (
+          <>
+            <h2 style={{ marginTop: 0 }}>You're signed in ✅</h2>
+            <p style={{ color: 'var(--text-secondary)' }}>
+              Your email is now linked. You can manage your hosted feeds from any device.
+            </p>
+            <a href="/" className="btn btn-primary" style={{ display: 'inline-block', marginTop: '12px', textDecoration: 'none' }}>
+              Continue to MSP
+            </a>
+          </>
+        )}
+        {status === 'error' && (
+          <>
+            <h2 style={{ marginTop: 0 }}>Link problem</h2>
+            <p style={{ color: 'var(--error, #ef4444)' }}>{error}</p>
+            <a href="/" className="btn btn-secondary" style={{ display: 'inline-block', marginTop: '12px', textDecoration: 'none' }}>
+              Back to MSP
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/utils/adminAuth.ts
+++ b/src/utils/adminAuth.ts
@@ -1,5 +1,6 @@
 // Admin authentication utilities for frontend
 import { hasSigner, signEventWithTimeout } from './nostrSigner';
+import { withEmailAuth, isEmailLoggedIn } from './emailSession';
 
 interface NostrEvent {
   id?: string;
@@ -101,6 +102,24 @@ export async function fetchAdminFeeds(): Promise<ListFeedsResponse> {
 
   if (!response.ok) {
     const error = await response.json();
+    throw new Error(error.error || 'Failed to fetch feeds');
+  }
+
+  return response.json();
+}
+
+// Fetch the feeds owned by the current email account
+export async function fetchEmailFeeds(): Promise<ListFeedsResponse> {
+  if (!isEmailLoggedIn()) {
+    throw new Error('Not logged in with email');
+  }
+
+  const response = await fetch('/api/account/feeds', {
+    headers: withEmailAuth()
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to fetch feeds' }));
     throw new Error(error.error || 'Failed to fetch feeds');
   }
 

--- a/src/utils/emailSession.ts
+++ b/src/utils/emailSession.ts
@@ -1,0 +1,68 @@
+// Frontend client for email magic-link auth (the non-Nostr feed-ownership path).
+import { emailSessionStorage, type EmailSessionInfo } from './storage';
+
+/** Current stored session, or null. */
+export function getEmailSession(): EmailSessionInfo | null {
+  return emailSessionStorage.load();
+}
+
+export function isEmailLoggedIn(): boolean {
+  return Boolean(emailSessionStorage.load()?.session);
+}
+
+export function setEmailSession(info: EmailSessionInfo): void {
+  emailSessionStorage.save(info);
+}
+
+export function clearEmailSession(): void {
+  emailSessionStorage.clear();
+}
+
+/** Merge the X-Email-Session header into a headers object when logged in. */
+export function withEmailAuth(headers: Record<string, string> = {}): Record<string, string> {
+  const session = emailSessionStorage.load()?.session;
+  return session ? { ...headers, 'X-Email-Session': `Bearer ${session}` } : headers;
+}
+
+/**
+ * Request a magic link. Always resolves on a 200 (enumeration-safe); throws only on
+ * transport/validation errors so the UI can show "check your inbox" without leaking
+ * whether the address exists.
+ */
+export async function requestMagicLink(
+  email: string,
+  opts: { purpose?: 'login' | 'claim'; feedId?: string; editToken?: string } = {}
+): Promise<void> {
+  const response = await fetch('/api/auth/magic-link', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, ...opts })
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ error: 'Failed to send link' }));
+    throw new Error(err.error || 'Failed to send link');
+  }
+}
+
+/**
+ * Redeem a magic-link token. On success, persists the session and returns it.
+ */
+export async function verifyMagicLink(token: string): Promise<EmailSessionInfo> {
+  const response = await fetch('/api/auth/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token })
+  });
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ error: 'Invalid or expired link' }));
+    throw new Error(err.error || 'Invalid or expired link');
+  }
+  const data = await response.json() as { session: string; emailHash: string };
+  const info: EmailSessionInfo = {
+    session: data.session,
+    emailHash: data.emailHash,
+    createdAt: Date.now()
+  };
+  emailSessionStorage.save(info);
+  return info;
+}

--- a/src/utils/hostedFeed.ts
+++ b/src/utils/hostedFeed.ts
@@ -2,6 +2,7 @@
 import { hostedFeedStorage, type HostedFeedInfo } from './storage';
 import { createAdminAuthHeader } from './adminAuth';
 import { hasSigner } from './nostrSigner';
+import { withEmailAuth, isEmailLoggedIn } from './emailSession';
 
 // Re-export type for backward compatibility
 export type { HostedFeedInfo };
@@ -251,6 +252,113 @@ export async function updateHostedFeedWithNostr(
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Failed to update feed' }));
     throw new Error(error.error || 'Failed to update feed');
+  }
+
+  return response.json();
+}
+
+// ============================================
+// Email-session-authenticated API functions
+// ============================================
+
+/**
+ * Create a hosted feed authenticated by the current email session (if any).
+ * Falls back to an anonymous create when not logged in with email.
+ */
+export async function createHostedFeedWithEmail(
+  xml: string,
+  title: string,
+  podcastGuid: string,
+  editToken?: string,
+  isDraft?: boolean
+): Promise<CreateFeedResponse> {
+  const response = await fetch('/api/hosted', {
+    method: 'POST',
+    headers: withEmailAuth({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ xml, title, podcastGuid, editToken, isDraft })
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to create feed' }));
+    throw new Error(error.error || 'Failed to create feed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Update a hosted feed using the current email session.
+ */
+export async function updateHostedFeedWithEmail(
+  feedId: string,
+  xml: string,
+  title: string,
+  isDraft?: boolean
+): Promise<UpdateFeedResponse> {
+  if (!isEmailLoggedIn()) {
+    throw new Error('Not logged in with email');
+  }
+
+  const response = await fetch(`/api/hosted/${feedId}`, {
+    method: 'PUT',
+    headers: withEmailAuth({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ xml, title, isDraft })
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to update feed' }));
+    throw new Error(error.error || 'Failed to update feed');
+  }
+
+  return response.json();
+}
+
+/**
+ * Delete a hosted feed using the current email session.
+ */
+export async function deleteHostedFeedWithEmail(feedId: string): Promise<void> {
+  if (!isEmailLoggedIn()) {
+    throw new Error('Not logged in with email');
+  }
+
+  const response = await fetch(`/api/hosted/${feedId}`, {
+    method: 'DELETE',
+    headers: withEmailAuth()
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to delete feed' }));
+    throw new Error(error.error || 'Failed to delete feed');
+  }
+}
+
+interface LinkEmailResponse {
+  success: boolean;
+  message: string;
+  emailLinked: boolean;
+}
+
+/**
+ * Claim an existing feed with the current email session.
+ * Requires the edit token (proves ownership); the session supplies the identity to attach.
+ * Mirrors linkNostrToFeed.
+ */
+export async function linkEmailToFeed(
+  feedId: string,
+  editToken: string
+): Promise<LinkEmailResponse> {
+  if (!isEmailLoggedIn()) {
+    throw new Error('Not logged in with email');
+  }
+
+  const response = await fetch(`/api/hosted/${feedId}`, {
+    method: 'PATCH',
+    headers: withEmailAuth({ 'X-Edit-Token': editToken })
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to link email identity' }));
+    throw new Error(error.error || 'Failed to link email identity');
   }
 
   return response.json();

--- a/src/utils/hostedFeed.ts
+++ b/src/utils/hostedFeed.ts
@@ -49,6 +49,23 @@ export function generateEditToken(): string {
 }
 
 /**
+ * Fetch a hosted-feed API endpoint, throwing a friendly error on a non-2xx
+ * (reusing the server's `error` field when present). Shared by every call below.
+ */
+async function hostedRequest<T = unknown>(
+  input: string,
+  init: RequestInit,
+  failMessage: string
+): Promise<T> {
+  const response = await fetch(input, init);
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: failMessage }));
+    throw new Error(error.error || failMessage);
+  }
+  return response.json();
+}
+
+/**
  * Create a new hosted feed
  */
 export async function createHostedFeed(
@@ -58,18 +75,11 @@ export async function createHostedFeed(
   editToken?: string,
   isDraft?: boolean
 ): Promise<CreateFeedResponse> {
-  const response = await fetch('/api/hosted', {
+  return hostedRequest<CreateFeedResponse>('/api/hosted', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ xml, title, podcastGuid, editToken, isDraft })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to create feed' }));
-    throw new Error(error.error || 'Failed to create feed');
-  }
-
-  return response.json();
+  }, 'Failed to create feed');
 }
 
 interface UpdateFeedResponse {
@@ -88,21 +98,14 @@ export async function updateHostedFeed(
   title: string,
   isDraft?: boolean
 ): Promise<UpdateFeedResponse> {
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  return hostedRequest<UpdateFeedResponse>(`/api/hosted/${feedId}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       'X-Edit-Token': editToken
     },
     body: JSON.stringify({ xml, title, isDraft })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to update feed' }));
-    throw new Error(error.error || 'Failed to update feed');
-  }
-
-  return response.json();
+  }, 'Failed to update feed');
 }
 
 /**
@@ -112,15 +115,10 @@ export async function deleteHostedFeed(
   feedId: string,
   editToken: string
 ): Promise<void> {
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  await hostedRequest(`/api/hosted/${feedId}`, {
     method: 'DELETE',
     headers: { 'X-Edit-Token': editToken }
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to delete feed' }));
-    throw new Error(error.error || 'Failed to delete feed');
-  }
+  }, 'Failed to delete feed');
 }
 
 /**
@@ -210,18 +208,11 @@ export async function createHostedFeedWithNostr(
     headers['Authorization'] = await createAdminAuthHeader(url, 'POST');
   }
 
-  const response = await fetch('/api/hosted', {
+  return hostedRequest<CreateFeedResponse>('/api/hosted', {
     method: 'POST',
     headers,
     body: JSON.stringify({ xml, title, podcastGuid, editToken, isDraft })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to create feed' }));
-    throw new Error(error.error || 'Failed to create feed');
-  }
-
-  return response.json();
+  }, 'Failed to create feed');
 }
 
 /**
@@ -240,21 +231,14 @@ export async function updateHostedFeedWithNostr(
   const url = `${window.location.origin}/api/hosted/${feedId}`;
   const authHeader = await createAdminAuthHeader(url, 'PUT');
 
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  return hostedRequest<UpdateFeedResponse>(`/api/hosted/${feedId}`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': authHeader
     },
     body: JSON.stringify({ xml, title, isDraft })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to update feed' }));
-    throw new Error(error.error || 'Failed to update feed');
-  }
-
-  return response.json();
+  }, 'Failed to update feed');
 }
 
 // ============================================
@@ -272,18 +256,11 @@ export async function createHostedFeedWithEmail(
   editToken?: string,
   isDraft?: boolean
 ): Promise<CreateFeedResponse> {
-  const response = await fetch('/api/hosted', {
+  return hostedRequest<CreateFeedResponse>('/api/hosted', {
     method: 'POST',
     headers: withEmailAuth({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ xml, title, podcastGuid, editToken, isDraft })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to create feed' }));
-    throw new Error(error.error || 'Failed to create feed');
-  }
-
-  return response.json();
+  }, 'Failed to create feed');
 }
 
 /**
@@ -299,18 +276,11 @@ export async function updateHostedFeedWithEmail(
     throw new Error('Not logged in with email');
   }
 
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  return hostedRequest<UpdateFeedResponse>(`/api/hosted/${feedId}`, {
     method: 'PUT',
     headers: withEmailAuth({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ xml, title, isDraft })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to update feed' }));
-    throw new Error(error.error || 'Failed to update feed');
-  }
-
-  return response.json();
+  }, 'Failed to update feed');
 }
 
 /**
@@ -321,15 +291,10 @@ export async function deleteHostedFeedWithEmail(feedId: string): Promise<void> {
     throw new Error('Not logged in with email');
   }
 
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  await hostedRequest(`/api/hosted/${feedId}`, {
     method: 'DELETE',
     headers: withEmailAuth()
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to delete feed' }));
-    throw new Error(error.error || 'Failed to delete feed');
-  }
+  }, 'Failed to delete feed');
 }
 
 interface LinkEmailResponse {
@@ -351,17 +316,10 @@ export async function linkEmailToFeed(
     throw new Error('Not logged in with email');
   }
 
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  return hostedRequest<LinkEmailResponse>(`/api/hosted/${feedId}`, {
     method: 'PATCH',
     headers: withEmailAuth({ 'X-Edit-Token': editToken })
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to link email identity' }));
-    throw new Error(error.error || 'Failed to link email identity');
-  }
-
-  return response.json();
+  }, 'Failed to link email identity');
 }
 
 interface LinkNostrResponse {
@@ -385,18 +343,11 @@ export async function linkNostrToFeed(
   const url = `${window.location.origin}/api/hosted/${feedId}`;
   const authHeader = await createAdminAuthHeader(url, 'PATCH');
 
-  const response = await fetch(`/api/hosted/${feedId}`, {
+  return hostedRequest<LinkNostrResponse>(`/api/hosted/${feedId}`, {
     method: 'PATCH',
     headers: {
       'X-Edit-Token': editToken,
       'Authorization': authHeader
     }
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to link Nostr identity' }));
-    throw new Error(error.error || 'Failed to link Nostr identity');
-  }
-
-  return response.json();
+  }, 'Failed to link Nostr identity');
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -10,7 +10,8 @@ export const STORAGE_KEYS = {
   FEED_TYPE: 'msp2-feed-type',
   NOSTR_USER: 'msp2-nostr-user',
   HOSTED_PREFIX: 'msp2-hosted-',
-  PENDING_HOSTED: 'msp2-pending-hosted'
+  PENDING_HOSTED: 'msp2-pending-hosted',
+  EMAIL_SESSION: 'msp2-email-session'
 } as const;
 
 // Migration helper: convert old person format to new format
@@ -154,9 +155,11 @@ export interface HostedFeedInfo {
   editToken: string;
   createdAt: number;
   lastUpdated: number;
-  ownerPubkey?: string;  // Nostr pubkey if linked
-  linkedAt?: number;     // When Nostr was linked
-  isDraft?: boolean;     // True when hosted without PI/podping notification
+  ownerPubkey?: string;     // Nostr pubkey if linked
+  linkedAt?: number;        // When Nostr was linked
+  ownerEmailHash?: string;  // Keyed HMAC of owner email if claimed via email
+  emailLinkedAt?: number;   // When the email was linked
+  isDraft?: boolean;        // True when hosted without PI/podping notification
 }
 
 // Hosted feed storage operations
@@ -176,4 +179,18 @@ export const pendingHostedStorage = {
   load: (): HostedFeedInfo | null => getItem<HostedFeedInfo>(STORAGE_KEYS.PENDING_HOSTED),
   save: (info: HostedFeedInfo): boolean => setItem(STORAGE_KEYS.PENDING_HOSTED, info),
   clear: (): boolean => removeItem(STORAGE_KEYS.PENDING_HOSTED)
+};
+
+// Email auth session (magic-link). The session JWT is opaque; emailHash identifies the account.
+export interface EmailSessionInfo {
+  session: string;    // signed session JWT sent as X-Email-Session: Bearer <session>
+  emailHash: string;  // server-issued opaque account id
+  email?: string;     // the address the user typed, kept locally for display only
+  createdAt: number;
+}
+
+export const emailSessionStorage = {
+  load: (): EmailSessionInfo | null => getItem<EmailSessionInfo>(STORAGE_KEYS.EMAIL_SESSION),
+  save: (info: EmailSessionInfo): boolean => setItem(STORAGE_KEYS.EMAIL_SESSION, info),
+  clear: (): boolean => removeItem(STORAGE_KEYS.EMAIL_SESSION)
 };

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,7 @@
     }
   ],
   "rewrites": [
-    { "source": "/admin", "destination": "/" }
+    { "source": "/admin", "destination": "/" },
+    { "source": "/auth/verify", "destination": "/" }
   ]
 }


### PR DESCRIPTION
Passwordless, non-Nostr, no-Google way for musicians to **own and recover MSP-hosted feeds** — a third owner type alongside the edit token and Nostr.

## ⚠️ DO NOT MERGE until the email infra is set up
This changes new-feed hosting to **require sign-in (email or Nostr)** and removes the token panel. The email magic-link send **404s in production until Resend + DNS + env vars exist**, so merging early would block real users (without Nostr) from hosting a new feed. Prerequisites:
- Resend account + verified `musicsideproject.com` sender
- DNS: SPF (`include:_spf.resend.com`), Resend DKIM, DMARC (`p=none`). No MX needed.
- Env vars: `RESEND_API_KEY`, `MSP_EMAIL_FROM`, `MSP_SESSION_SECRET`, `MSP_EMAIL_HASH_KEY` (keep the last two fixed), optional `MSP_MAGIC_LINK_TTL_MIN`.

## What it does
- **Auth model**: magic link → stateless HS256 session (`X-Email-Session`). Raw email is never persisted — only a keyed-HMAC `emailHash`. Blob storage uses unguessable paths (`@vercel/blob` has no private mode).
- **Endpoints**: `api/auth/magic-link` (rate-limited, enumeration-safe, claim proves the edit token first), `api/auth/verify` (single-use redeem → session, stamps ownership), `api/account/feeds`.
- **Hosted writes**: `ownerEmailHash` in metadata; PUT/DELETE/PATCH accept an email owner. Also **fixes the DELETE-has-no-owner-path gap** for both Nostr and email.
- **UI**: new feeds require sign-in (email/Nostr), token panel removed; restored token feeds get a "switch to your account" prompt; email "My Feeds" in the Import modal.

## Refactor included
- `hostedRequest()` helper (dedupes ~9 response handlers) and `isAuthorizedFeedWrite()` (shared PUT/DELETE auth ladder).

## Verification
`npm run build` clean, **182 tests pass**, production code lint-clean. Architecture + env/DNS documented in CLAUDE.md.

## Known follow-ups (deferred)
Publisher "Browse My MSP Feeds" and the `/admin` dashboard aren't email-aware yet; NIP-98 events still aren't bound to URL/method (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)