### PR TITLE
Require login for MSP hosting writes; make login primary in import flow

### DIFF
--- a/src/components/auth/SignInPrompt.tsx
+++ b/src/components/auth/SignInPrompt.tsx
@@ -1,0 +1,39 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+interface SignInPromptProps {
+  title: string;
+  blurb: string;
+  onEmail: () => void;
+  onNostr: () => void;
+  /** Margin/layout overrides for the panel container */
+  style?: CSSProperties;
+  /** Extra content rendered below the sign-in buttons (e.g. a restore link) */
+  children?: ReactNode;
+}
+
+/**
+ * Purple "Sign in with email / Sign in with Nostr" CTA panel shared by the
+ * Save and Import modals. Callers own the modals the buttons open — pass
+ * handlers that show EmailLoginModal / NostrConnectModal.
+ */
+export function SignInPrompt({ title, blurb, onEmail, onNostr, style, children }: SignInPromptProps) {
+  return (
+    <div style={{ padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)', ...style }}>
+      <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
+        {title}
+      </p>
+      <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
+        {blurb}
+      </p>
+      <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+        <button className="btn btn-primary" style={{ fontSize: '0.8rem' }} onClick={onEmail}>
+          Sign in with email
+        </button>
+        <button className="btn btn-secondary" style={{ fontSize: '0.8rem' }} onClick={onNostr}>
+          Sign in with Nostr
+        </button>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -6,6 +6,7 @@ import { type HostedFeedInfo, buildHostedUrl } from '../../utils/hostedFeed';
 import { fetchAdminFeeds, fetchEmailFeeds } from '../../utils/adminAuth';
 import { isEmailLoggedIn, getEmailSession } from '../../utils/emailSession';
 import { EmailLoginModal } from '../auth/EmailLoginModal';
+import { NostrConnectModal } from './NostrConnectModal';
 import { pendingHostedStorage } from '../../utils/storage';
 import { formatTimestamp } from '../../utils/dateUtils';
 import { checkSignerConnection } from '../../utils/nostrSigner';
@@ -54,6 +55,10 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
   const [hostedFeeds, setHostedFeeds] = useState<HostedFeedListItem[]>([]);
   const [loadingHostedFeeds, setLoadingHostedFeeds] = useState(false);
   const [showEmailLogin, setShowEmailLogin] = useState(false);
+  const [showNostrConnect, setShowNostrConnect] = useState(false);
+  // Manual Feed-ID / edit-token / backup entry is collapsed by default now that
+  // signing in is the primary way to find your feeds — this is the "I have a token" path.
+  const [showManualImport, setShowManualImport] = useState(false);
 
   // Reset mode if the current selection is an experimental option that just got hidden
   useEffect(() => {
@@ -61,6 +66,12 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
       setMode('file');
     }
   }, [showExperimental, mode]);
+
+  // Once the user signs in (Nostr) while on the MSP Hosted tab, load their feeds.
+  useEffect(() => {
+    if (mode === 'hosted' && isLoggedIn) fetchHostedFeeds();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, isLoggedIn]);
 
   const fetchSavedAlbums = async () => {
     const pubkey = nostrState.user?.pubkey;
@@ -356,9 +367,11 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                     {loadingHostedFeeds ? 'Loading...' : 'Refresh'}
                   </button>
                 )}
-                <button className="btn btn-primary" onClick={handleImportHosted} disabled={loading || !hostedFeedId.trim()}>
-                  {loading ? 'Importing...' : 'Import by ID'}
-                </button>
+                {showManualImport && (
+                  <button className="btn btn-primary" onClick={handleImportHosted} disabled={loading || !hostedFeedId.trim()}>
+                    {loading ? 'Importing...' : 'Import by ID'}
+                  </button>
+                )}
               </>
             ) : (
               <button className="btn btn-primary" onClick={handleImport} disabled={loading}>
@@ -585,31 +598,48 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                       );
                     })}
                   </select>
+                </div>
+              )}
 
-                  {/* Divider */}
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px', margin: '16px 0' }}>
-                    <div style={{ flex: 1, height: '1px', backgroundColor: 'var(--border-color)' }} />
-                    <span style={{ fontSize: '0.7rem', color: 'var(--text-secondary)' }}>OR IMPORT BY BACKUP/ID</span>
-                    <div style={{ flex: 1, height: '1px', backgroundColor: 'var(--border-color)' }} />
+              {/* Logged out: signing in is the primary way to find your hosted feeds. */}
+              {!canListFeeds && (
+                <div style={{ marginBottom: '16px', padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
+                  <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
+                    Sign in to see your feeds
+                  </p>
+                  <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
+                    Sign in with email or Nostr to browse and import every feed you've hosted on MSP — no Feed ID needed.
+                  </p>
+                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                    <button
+                      className="btn btn-primary"
+                      style={{ fontSize: '0.8rem' }}
+                      onClick={() => setShowEmailLogin(true)}
+                    >
+                      Sign in with email
+                    </button>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ fontSize: '0.8rem' }}
+                      onClick={() => setShowNostrConnect(true)}
+                    >
+                      Sign in with Nostr
+                    </button>
                   </div>
                 </div>
               )}
 
-              {!canListFeeds && (
-                <div style={{ marginBottom: '12px' }}>
-                  <p style={{ color: 'var(--text-secondary)', fontSize: '0.875rem', marginBottom: '8px' }}>
-                    Import a feed hosted on MSP. Upload your backup file or enter details manually.
-                  </p>
-                  <button
-                    className="btn btn-secondary"
-                    style={{ fontSize: '0.75rem' }}
-                    onClick={() => setShowEmailLogin(true)}
-                  >
-                    Sign in with email to see your feeds
-                  </button>
-                </div>
-              )}
+              {/* Advanced / token path: collapsed by default. */}
+              <button
+                type="button"
+                style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', fontSize: '0.8rem', textDecoration: 'underline', cursor: 'pointer', padding: 0, marginBottom: showManualImport ? '12px' : 0 }}
+                onClick={() => setShowManualImport(v => !v)}
+              >
+                {showManualImport ? 'Hide manual import' : 'Have a Feed ID or edit token? Import manually'}
+              </button>
 
+              {showManualImport && (
+              <>
               {/* Upload backup file */}
               <label
                 style={{
@@ -689,8 +719,10 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                 style={{ fontFamily: 'monospace' }}
               />
               <p style={{ color: 'var(--text-secondary)', fontSize: '0.75rem', marginTop: '8px' }}>
-                If you have your edit token, enter it to enable editing after import.
+                If you have your edit token, enter it to enable editing after import. You'll still need to sign in to save changes.
               </p>
+              </>
+              )}
             </div>
           ) : (
             <div className="form-group">
@@ -727,7 +759,7 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                 <li><strong>Upload File</strong> - Upload an RSS/XML feed file from your device</li>
                 <li><strong>Paste XML</strong> - Paste RSS/XML content directly</li>
                 <li><strong>From URL</strong> - Fetch a feed from any URL</li>
-                <li><strong>MSP Hosted</strong> - Load a feed hosted on MSP servers using its Feed ID</li>
+                <li><strong>MSP Hosted</strong> - Sign in with email or Nostr to browse and import your hosted feeds. If you have a saved Feed ID or edit token, you can still import manually.</li>
                 <li><strong>From Nostr Music</strong> - Import tracks from Nostr Music library (requires login)</li>
                 {showExperimental && <li><strong>Nostr Event 🧪</strong> - Import from a Nostr Event (kind 36787)</li>}
                 {showExperimental && <li><strong>From Nostr 🧪</strong> - Load your previously saved albums from Nostr (requires login)</li>}
@@ -736,7 +768,13 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
       )}
 
       {showEmailLogin && (
-        <EmailLoginModal onClose={() => setShowEmailLogin(false)} />
+        <EmailLoginModal onClose={() => {
+          setShowEmailLogin(false);
+          if (mode === 'hosted' && isEmailLoggedIn()) fetchHostedFeeds();
+        }} />
+      )}
+      {showNostrConnect && (
+        <NostrConnectModal onClose={() => setShowNostrConnect(false)} />
       )}
     </>
   );

--- a/src/components/modals/ImportModal.tsx
+++ b/src/components/modals/ImportModal.tsx
@@ -6,6 +6,7 @@ import { type HostedFeedInfo, buildHostedUrl } from '../../utils/hostedFeed';
 import { fetchAdminFeeds, fetchEmailFeeds } from '../../utils/adminAuth';
 import { isEmailLoggedIn, getEmailSession } from '../../utils/emailSession';
 import { EmailLoginModal } from '../auth/EmailLoginModal';
+import { SignInPrompt } from '../auth/SignInPrompt';
 import { NostrConnectModal } from './NostrConnectModal';
 import { pendingHostedStorage } from '../../utils/storage';
 import { formatTimestamp } from '../../utils/dateUtils';
@@ -67,9 +68,14 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
     }
   }, [showExperimental, mode]);
 
-  // Once the user signs in (Nostr) while on the MSP Hosted tab, load their feeds.
+  // Load the account's feeds when the MSP Hosted tab is active — fires on
+  // switching to the tab (any sign-in type) and on Nostr sign-in while on it.
+  // This is the single trigger for the tab switch; the select onChange must not
+  // also call fetchHostedFeeds or Nostr users get two signer prompts. Email
+  // sign-in while on the tab is handled by the EmailLoginModal onClose below
+  // (isEmailLoggedIn() reads localStorage, so it can't be an effect dep).
   useEffect(() => {
-    if (mode === 'hosted' && isLoggedIn) fetchHostedFeeds();
+    if (mode === 'hosted' && canListFeeds) fetchHostedFeeds();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, isLoggedIn]);
 
@@ -406,7 +412,7 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
                 setMode(newMode);
                 if (newMode === 'nostr') fetchSavedAlbums();
                 if (newMode === 'nostrMusic') fetchMusicTracks();
-                if (newMode === 'hosted' && canListFeeds) fetchHostedFeeds();
+                // 'hosted' fetch happens in the mode/isLoggedIn effect above
               }}
             >
               <option value="file">Upload File</option>
@@ -603,30 +609,13 @@ export function ImportModal({ onClose, onImport, onLoadAlbum, isLoggedIn, templa
 
               {/* Logged out: signing in is the primary way to find your hosted feeds. */}
               {!canListFeeds && (
-                <div style={{ marginBottom: '16px', padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
-                  <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
-                    Sign in to see your feeds
-                  </p>
-                  <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
-                    Sign in with email or Nostr to browse and import every feed you've hosted on MSP — no Feed ID needed.
-                  </p>
-                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                    <button
-                      className="btn btn-primary"
-                      style={{ fontSize: '0.8rem' }}
-                      onClick={() => setShowEmailLogin(true)}
-                    >
-                      Sign in with email
-                    </button>
-                    <button
-                      className="btn btn-secondary"
-                      style={{ fontSize: '0.8rem' }}
-                      onClick={() => setShowNostrConnect(true)}
-                    >
-                      Sign in with Nostr
-                    </button>
-                  </div>
-                </div>
+                <SignInPrompt
+                  style={{ marginBottom: '16px' }}
+                  title="Sign in to see your feeds"
+                  blurb="Sign in with email or Nostr to browse and import every feed you've hosted on MSP — no Feed ID needed."
+                  onEmail={() => setShowEmailLogin(true)}
+                  onNostr={() => setShowNostrConnect(true)}
+                />
               )}
 
               {/* Advanced / token path: collapsed by default. */}

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -109,7 +109,6 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   const [restoreLoading, setRestoreLoading] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [pendingToken, setPendingToken] = useState<string | null>(null);
-  const [tokenAcknowledged, setTokenAcknowledged] = useState(false);
   const [linkingNostr, setLinkingNostr] = useState(false);
   const [linkingEmail, setLinkingEmail] = useState(false);
   const [emailModal, setEmailModal] = useState<null | { mode: 'login' } | { mode: 'claim' }>(null);
@@ -153,9 +152,12 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
   // Helper to determine if button should be disabled
   const isButtonDisabled = () => {
     if (loading) return true;
-    // Signed-in users (email or Nostr) don't need to babysit a token — their identity
-    // is the recovery — so the "I saved my token" gate only applies to anonymous hosting.
-    if (mode === 'hosted' && !hostedInfo && !legacyHostedInfo && !tokenAcknowledged && !isEmailLoggedIn() && !isLoggedIn) return true;
+    // Every MSP-hosting write (create a new feed OR update an existing one) now
+    // requires being signed in with email or Nostr. The edit token alone no longer
+    // authorizes a save from the main button — it's only used to auto-claim a
+    // token-owned feed onto the account on the first signed-in save. (Token holders
+    // can still recover a feed via the "Restore" panel below.)
+    if (mode === 'hosted' && !isEmailLoggedIn() && !isLoggedIn) return true;
     if (mode === 'podcastIndex' && (!podcastIndexSubmitUrl.trim() || !!podcastIndexUrlError)) return true;
     return false;
   };
@@ -414,7 +416,10 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
     // For NIP-46 remote signers (Primal, Amber) this may require the user to approve
     // in their signer app — show a hint so they know to switch apps.
     const nostrSignModes = ['nostr', 'nostrMusic', 'blossom', 'nsite'] as const;
-    if ((nostrSignModes as readonly string[]).includes(mode)) {
+    // Hosted saves also sign with Nostr when the user is logged in with Nostr
+    // (creating/claiming/updating an account-owned feed), so pre-flight those too.
+    const hostedWillSignNostr = mode === 'hosted' && isLoggedIn && !!nostrState.user?.pubkey;
+    if ((nostrSignModes as readonly string[]).includes(mode) || hostedWillSignNostr) {
       setMessage({ type: 'success', text: 'Connecting to signer — if using a remote signer (Primal, Amber), open the app and approve now.' });
       const health = await checkSignerConnection();
       setMessage(null);
@@ -549,16 +554,45 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
           }
 
           if (hostedInfo) {
-            // Update existing feed - prefer Nostr, then email session, else token
-            let updateResult;
-            if (isNostrLinked) {
-              updateResult = await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
-            } else if (isEmailLinked) {
-              updateResult = await updateHostedFeedWithEmail(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
-            } else {
-              updateResult = await updateHostedFeed(hostedInfo.feedId, hostedInfo.editToken, hostedXml, currentFeedTitle, isDraft);
+            // Saving changes to an existing hosted feed now requires being signed in.
+            // The edit token alone no longer authorizes an update here.
+            const useNostr = isLoggedIn && !!nostrState.user?.pubkey;
+            const useEmail = !useNostr && isEmailLoggedIn();
+            if (!useNostr && !useEmail) {
+              setMessage({ type: 'error', text: 'Sign in with email or Nostr to save changes to your hosted feed.' });
+              setLoading(false);
+              return;
             }
-            const updatedInfo = { ...hostedInfo, lastUpdated: Date.now(), isDraft: updateResult.isDraft || undefined };
+
+            // If the feed is still token-owned, saving auto-claims it onto the
+            // signed-in account (best-effort) so the token is retired going forward.
+            let claimed: 'nostr' | 'email' | null = null;
+            if (useNostr && !isNostrLinked && hostedInfo.editToken) {
+              try {
+                await linkNostrToFeed(hostedInfo.feedId, hostedInfo.editToken);
+                claimed = 'nostr';
+              } catch (claimErr) {
+                console.warn('Auto-claim to Nostr failed:', claimErr);
+              }
+            } else if (useEmail && !isEmailLinked && hostedInfo.editToken) {
+              try {
+                await linkEmailToFeed(hostedInfo.feedId, hostedInfo.editToken);
+                claimed = 'email';
+              } catch (claimErr) {
+                console.warn('Auto-claim to email failed:', claimErr);
+              }
+            }
+
+            const updateResult = useNostr
+              ? await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft)
+              : await updateHostedFeedWithEmail(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
+            const updatedInfo: HostedFeedInfo = {
+              ...hostedInfo,
+              lastUpdated: Date.now(),
+              isDraft: updateResult.isDraft || undefined,
+              ...(claimed === 'nostr' ? { ownerPubkey: nostrState.user!.pubkey, linkedAt: Date.now() } : {}),
+              ...(claimed === 'email' ? { ownerEmailHash: emailSession?.emailHash, emailLinkedAt: Date.now() } : {}),
+            };
             saveHostedFeedInfo(currentFeedGuid, updatedInfo);
             setHostedInfo(updatedInfo);
 
@@ -620,7 +654,6 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
             setHostedUrl(buildHostedUrl(hostedResult.feedId));
             setPendingToken(null);
             setLegacyHostedInfo(null);
-            setTokenAcknowledged(false);
 
             if (isDraft) {
               setMessage({ type: 'success', text: 'Feed saved as draft! Podcast Index not notified.' });
@@ -1106,6 +1139,33 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                         ? 'Host your RSS feed on MSP — it will be linked to your Nostr identity, manageable from any device.'
                         : 'Host your RSS feed on MSP — get a permanent URL for any podcast app.'}
               </p>
+              {/* Updating an existing (e.g. imported token-owned) feed now requires signing in. */}
+              {hostedInfo && !isLoggedIn && !isEmailLoggedIn() && (
+                <div style={{ marginTop: '12px', padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
+                  <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
+                    Sign in to save changes
+                  </p>
+                  <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
+                    Saving updates to an MSP-hosted feed requires signing in. If this feed used an edit token, signing in claims it to your account so you won't need the token again.
+                  </p>
+                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+                    <button
+                      className="btn btn-primary"
+                      style={{ fontSize: '0.8rem' }}
+                      onClick={() => setEmailModal({ mode: 'login' })}
+                    >
+                      Sign in with email
+                    </button>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ fontSize: '0.8rem' }}
+                      onClick={() => setShowNostrConnect(true)}
+                    >
+                      Sign in with Nostr
+                    </button>
+                  </div>
+                </div>
+              )}
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '0.875rem', marginTop: '12px' }}>
                 <input
                   type="checkbox"
@@ -1155,7 +1215,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                   </div>
                   <button
                     style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', fontSize: '0.7rem', textDecoration: 'underline', cursor: 'pointer', marginTop: '10px', padding: 0 }}
-                    onClick={() => { setPendingToken(null); setTokenAcknowledged(false); setShowRestore(true); }}
+                    onClick={() => { setPendingToken(null); setShowRestore(true); }}
                   >
                     Already have a feed with an edit token? Restore it
                   </button>
@@ -1557,7 +1617,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                 <li><strong>Local Storage</strong> - Save to your browser's local storage. Data persists until you clear browser data.</li>
                 <li><strong>Download XML</strong> - Download the RSS feed as an XML file to your computer.</li>
                 <li><strong>Copy to Clipboard</strong> - Copy the RSS XML to your clipboard for pasting elsewhere.</li>
-                <li><strong>Host on MSP</strong> - Host your feed on MSP servers. Get a permanent URL for your RSS feed to use in any app. Enable "Draft mode" to host without notifying Podcast Index or sending a podping.{isLoggedIn && ' You can link your Nostr identity to edit from any device without needing the token.'}</li>
+                <li><strong>Host on MSP</strong> - Host your feed on MSP servers. Get a permanent URL for your RSS feed to use in any app. Requires signing in with email or Nostr so the feed is owned by your account and editable from any device. Enable "Draft mode" to host without notifying Podcast Index or sending a podping.</li>
                 <li><strong>Submit to PodcastIndex</strong> - Submit a feed URL to Podcast Index so it gets indexed and becomes discoverable in apps like Fountain, Castamatic, and others.</li>
                 <li><strong>Publish to Nostr Music</strong> - Publishes each track (kind 36787) and the playlist (kind 34139) as Nostr events for Nostr-native music apps like Sunami. Audio files must already be hosted somewhere - these events just point to them. Not a podcast RSS feed.</li>
                 {showExperimental && <li><strong>Save RSS feed to Nostr 🧪</strong> - Stores the entire RSS XML inside a Nostr event (kind 30054) on your relays. Personal cross-device backup tied to your Nostr key. Not readable by podcast apps.</li>}

--- a/src/components/modals/SaveModal.tsx
+++ b/src/components/modals/SaveModal.tsx
@@ -26,6 +26,7 @@ import {
 import { albumStorage, videoStorage, publisherStorage, pendingHostedStorage } from '../../utils/storage';
 import { getEmailSession, isEmailLoggedIn } from '../../utils/emailSession';
 import { EmailLoginModal } from '../auth/EmailLoginModal';
+import { SignInPrompt } from '../auth/SignInPrompt';
 import { NostrConnectModal } from './NostrConnectModal';
 import { useNostr } from '../../store/nostrStore';
 import { useExperimental } from '../../store/experimentalStore';
@@ -556,13 +557,20 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
           if (hostedInfo) {
             // Saving changes to an existing hosted feed now requires being signed in.
             // The edit token alone no longer authorizes an update here.
-            const useNostr = isLoggedIn && !!nostrState.user?.pubkey;
-            const useEmail = !useNostr && isEmailLoggedIn();
-            if (!useNostr && !useEmail) {
+            const nostrAvailable = isLoggedIn && !!nostrState.user?.pubkey;
+            const emailAvailable = isEmailLoggedIn();
+            if (!nostrAvailable && !emailAvailable) {
               setMessage({ type: 'error', text: 'Sign in with email or Nostr to save changes to your hosted feed.' });
               setLoading(false);
               return;
             }
+
+            // Pick the update path by which identity actually OWNS the feed
+            // (matching the server's auth ladder) — a feed claimed by email must
+            // update via the email session even if the user is also Nostr-logged-in,
+            // and vice versa. Only unclaimed feeds fall back to the login method.
+            const useNostr = isNostrLinked ? true : isEmailLinked ? false : nostrAvailable;
+            const useEmail = !useNostr && emailAvailable;
 
             // If the feed is still token-owned, saving auto-claims it onto the
             // signed-in account (best-effort) so the token is retired going forward.
@@ -583,15 +591,27 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
               }
             }
 
-            const updateResult = useNostr
-              ? await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft)
-              : await updateHostedFeedWithEmail(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
+            let updateResult;
+            try {
+              updateResult = useNostr
+                ? await updateHostedFeedWithNostr(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft)
+                : await updateHostedFeedWithEmail(hostedInfo.feedId, hostedXml, currentFeedTitle, isDraft);
+            } catch (updateErr) {
+              // The account-owned path can fail while a valid edit token is in hand:
+              // the auto-claim above failed (signer rejected, network blip), the feed
+              // predates .meta.json (PATCH 404s, PUT demands the raw token), or the
+              // claim's metadata write hasn't propagated yet. Fall back to the token
+              // so a legitimate token holder can always save.
+              if (!hostedInfo.editToken) throw updateErr;
+              console.warn('Account-owned update failed, retrying with edit token:', updateErr);
+              updateResult = await updateHostedFeed(hostedInfo.feedId, hostedInfo.editToken, hostedXml, currentFeedTitle, isDraft);
+            }
             const updatedInfo: HostedFeedInfo = {
               ...hostedInfo,
               lastUpdated: Date.now(),
               isDraft: updateResult.isDraft || undefined,
               ...(claimed === 'nostr' ? { ownerPubkey: nostrState.user!.pubkey, linkedAt: Date.now() } : {}),
-              ...(claimed === 'email' ? { ownerEmailHash: emailSession?.emailHash, emailLinkedAt: Date.now() } : {}),
+              ...(claimed === 'email' ? { ownerEmailHash: getEmailSession()?.emailHash, emailLinkedAt: Date.now() } : {}),
             };
             saveHostedFeedInfo(currentFeedGuid, updatedInfo);
             setHostedInfo(updatedInfo);
@@ -635,7 +655,7 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                 editToken: tokenToUse,
                 createdAt: Date.now(),
                 lastUpdated: Date.now(),
-                ownerEmailHash: emailSession?.emailHash,
+                ownerEmailHash: getEmailSession()?.emailHash,
                 emailLinkedAt: Date.now(),
                 ...(hostedResult.isDraft && { isDraft: true })
               };
@@ -1139,32 +1159,15 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
                         ? 'Host your RSS feed on MSP — it will be linked to your Nostr identity, manageable from any device.'
                         : 'Host your RSS feed on MSP — get a permanent URL for any podcast app.'}
               </p>
-              {/* Updating an existing (e.g. imported token-owned) feed now requires signing in. */}
-              {hostedInfo && !isLoggedIn && !isEmailLoggedIn() && (
-                <div style={{ marginTop: '12px', padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
-                  <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
-                    Sign in to save changes
-                  </p>
-                  <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
-                    Saving updates to an MSP-hosted feed requires signing in. If this feed used an edit token, signing in claims it to your account so you won't need the token again.
-                  </p>
-                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
-                    <button
-                      className="btn btn-primary"
-                      style={{ fontSize: '0.8rem' }}
-                      onClick={() => setEmailModal({ mode: 'login' })}
-                    >
-                      Sign in with email
-                    </button>
-                    <button
-                      className="btn btn-secondary"
-                      style={{ fontSize: '0.8rem' }}
-                      onClick={() => setShowNostrConnect(true)}
-                    >
-                      Sign in with Nostr
-                    </button>
-                  </div>
-                </div>
+              {/* Updating an existing (e.g. imported token-owned or legacy) feed now requires signing in. */}
+              {(hostedInfo || legacyHostedInfo) && !isLoggedIn && !isEmailLoggedIn() && (
+                <SignInPrompt
+                  style={{ marginTop: '12px' }}
+                  title="Sign in to save changes"
+                  blurb="Saving updates to an MSP-hosted feed requires signing in. If this feed used an edit token, signing in claims it to your account so you won't need the token again."
+                  onEmail={() => setEmailModal({ mode: 'login' })}
+                  onNostr={() => setShowNostrConnect(true)}
+                />
               )}
               <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '0.875rem', marginTop: '12px' }}>
                 <input
@@ -1190,36 +1193,20 @@ export function SaveModal({ onClose, album, publisherFeed, feedType = 'album', i
               )}
               {/* Logged-out users must sign in to host a NEW feed. Tokens are no longer offered for new feeds. */}
               {!hostedInfo && !legacyHostedInfo && !isEmailLoggedIn() && !isLoggedIn && !showRestore && (
-                <div style={{ marginTop: '16px', padding: '16px', backgroundColor: 'rgba(124, 58, 237, 0.08)', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
-                  <p style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--text-primary)', marginTop: 0, marginBottom: '4px' }}>
-                    Sign in to host your feed
-                  </p>
-                  <p style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginBottom: '12px' }}>
-                    Sign in with your email or Nostr so this feed is owned by your account — manage it from any device, nothing to keep safe.
-                  </p>
-                  <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
-                    <button
-                      className="btn btn-primary"
-                      style={{ fontSize: '0.8rem' }}
-                      onClick={() => setEmailModal({ mode: 'login' })}
-                    >
-                      Sign in with email
-                    </button>
-                    <button
-                      className="btn btn-secondary"
-                      style={{ fontSize: '0.8rem' }}
-                      onClick={() => setShowNostrConnect(true)}
-                    >
-                      Sign in with Nostr
-                    </button>
-                  </div>
+                <SignInPrompt
+                  style={{ marginTop: '16px' }}
+                  title="Sign in to host your feed"
+                  blurb="Sign in with your email or Nostr so this feed is owned by your account — manage it from any device, nothing to keep safe."
+                  onEmail={() => setEmailModal({ mode: 'login' })}
+                  onNostr={() => setShowNostrConnect(true)}
+                >
                   <button
                     style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', fontSize: '0.7rem', textDecoration: 'underline', cursor: 'pointer', marginTop: '10px', padding: 0 }}
                     onClick={() => { setPendingToken(null); setShowRestore(true); }}
                   >
                     Already have a feed with an edit token? Restore it
                   </button>
-                </div>
+                </SignInPrompt>
               )}
               {/* Calm "owned by your account" note for signed-in users — no token to manage. */}
               {pendingToken && !hostedInfo && !legacyHostedInfo && (isEmailLoggedIn() || isLoggedIn) && (


### PR DESCRIPTION
Move MSP feed hosting away from edit tokens toward account ownership:

SaveModal (Host on MSP):
- Saving changes to an existing hosted feed now requires signing in with
  email or Nostr. The edit token alone no longer authorizes an update from
  the main Save button.
- On the first signed-in save of a token-owned feed, auto-claim it onto the
  account (link email/Nostr via the edit token) so the token is retired.
- Add a "Sign in to save changes" prompt when a logged-out user opens an
  imported/token-owned feed.
- Simplify the button-disabled gate: all hosted writes require login. Remove
  the now-defunct tokenAcknowledged state (never set true).
- Pre-flight the Nostr signer for hosted saves that will sign.

ImportModal (MSP Hosted):
- Make signing in the primary action for finding your hosted feeds; add a
  "Sign in with Nostr" option alongside email and auto-load feeds after login.
- Collapse the manual Feed ID / edit token / backup-file entry behind an
  "Have a Feed ID or edit token? Import manually" disclosure.

Importing a feed (public XML) still works without login; the token path
remains available for recovery.

Co-Authored-By: Claude <noreply@anthropic.com>