### PR TITLE
Explain the pub date convention in the Pub Date help text

### DIFF
--- a/src/data/fieldInfo.ts
+++ b/src/data/fieldInfo.ts
@@ -58,7 +58,7 @@ export const FIELD_INFO = {
   trackTitle: "The song title.",
   trackDescription: "Optional description or notes about the track.",
   trackDuration: "Total duration in HH:MM:SS format. Required for podcast apps.",
-  trackPubDate: "Publication date/time for this track. Used for sorting and display in podcast apps.",
+  trackPubDate: "Publication date/time for this track. Filled in automatically and kept in order for you — podcast apps sort newest-first, so track 1 gets the newest date and the album plays top to bottom. Only change this if a track has a real release date of its own; setting them out of order will play the album out of order.",
   trackSeason: "Season number for grouping tracks (e.g., 1 for first album). Optional.",
   trackEpisode: "Episode number for this track. Defaults to track order if not set.",
   enclosureUrl: "Direct link to the audio file. MP3 is preferred — smaller file size saves bandwidth for listeners. Other formats (flac, wav, m4a, aac, ogg, opus, aiff) are also supported. Ensure CORS policy allows access.",


### PR DESCRIPTION
Follow-up to #97.

The ℹ️ help text on a track's Pub Date field still read:

> Publication date/time for this track. Used for sorting and display in podcast apps.

That was written when you set these dates by hand. Now that `ADD_TRACK` and `REORDER_TRACKS` keep them descending, the field is auto-managed — and nothing told the user that track 1 carries the newest date **on purpose**. Someone tidying up dates by hand could quietly undo the fix and put their album back out of order, which is the exact bug #94 reported.

New text explains the convention and scopes when it's legitimate to override (a track with a real release date of its own).

Docs only — no behavior change. `npm run build` and `npm run test` (401) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGuyhdmSTyUNpJZYy42gfB