### PR TITLE
Run the tests on PRs, and typecheck api/ at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+# Runs the checks that Vercel doesn't.
+#
+# Vercel's build posts a green check on every PR, which reads like "CI passed" but
+# only means `npm run build` succeeded. Nothing ran the 475 unit tests or ESLint, so
+# a PR could break every test and still merge green. That's what this fixes.
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# A new push to a PR makes the previous run irrelevant; don't pay for it.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      # tsc -b covers src, vite.config.ts AND api (tsconfig.api.json), then vite build.
+      # Deliberately `npm run build` rather than `tsc --noEmit`: the root tsconfig is
+      # references-only, so --noEmit against it checks zero files and always passes.
+      - name: Build (typecheck + bundle)
+        run: npm run build
+
+      - name: Test
+        run: npm run test
+
+      # Non-blocking for now: master carries 29 pre-existing problems, and failing
+      # every PR on them would just train people to ignore this job. Flip to blocking
+      # once the backlog is cleared.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,12 @@ npm run dev
 - Build auto-unshallows Vercel's git clone for accurate version computation
 
 ### Typechecking — use `npm run build`, not `tsc --noEmit`
-The root `tsconfig.json` is **references-only** (`files: []` + references to `tsconfig.app.json` / `tsconfig.node.json`), so `tsc --noEmit` against it checks **zero files** and always passes — a false green. Always verify types with `npm run build` (`tsc -b && vite build`) or at minimum `npx tsc -b`. (Lint is separate: `npm run lint`.)
+The root `tsconfig.json` is **references-only** (`files: []` + references to `tsconfig.app.json` / `tsconfig.node.json` / `tsconfig.api.json`), so `tsc --noEmit` against it checks **zero files** and always passes — a false green. Always verify types with `npm run build` (`tsc -b && vite build`) or at minimum `npx tsc -b`. (Lint is separate: `npm run lint`.)
+
+`tsconfig.api.json` exists because `api/` used to be typechecked by **nothing** — `tsconfig.app.json` includes only `src`, `tsconfig.node.json` only `vite.config.ts`, and Vercel's builder transpiles functions without checking them. Roughly 8k lines, including every auth path, the SSRF guards and feed CRUD, had no type gate. It excludes `api/**/*.test.ts` on purpose: handler tests pass `vi.fn()` mocks where a full `VercelResponse` is expected, which is normal for that style of test and would bury real errors in ~30 fake ones.
+
+### CI — Vercel's green check is not a passing test run
+`.github/workflows/ci.yml` runs `npm run build`, `npm run test` and `npm run lint` on every PR and on pushes to `master`. Before it existed the only checks were **Vercel** and **Vercel Preview Comments** — a build and a deploy — so a PR could break all 475 tests and still show green. Lint is `continue-on-error` while master carries pre-existing problems; make it blocking once that backlog is clear.
 
 ### Domains & canonical URL
 Hosted feed URLs (album/video/publisher) **always** use the canonical domain, never the request host:

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,42 @@
+{
+  /*
+   * Vercel serverless functions. Split from tsconfig.node.json (which covers only
+   * vite.config.ts) because api/ needs DOM lib for the Web fetch/Response/AbortSignal
+   * types the handlers use, while running under Node types.
+   *
+   * Before this file existed, api/ was typechecked by NOTHING: tsconfig.app.json
+   * includes only "src", tsconfig.node.json only "vite.config.ts", and Vercel's
+   * builder transpiles without checking. That left the auth, SSRF-guard and feed-CRUD
+   * code — the highest-consequence code in the repo — with no type gate at all.
+   */
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.api.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Handlers import siblings with a .js specifier that resolves to .ts */
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Same strictness as the app project */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["api"],
+  /*
+   * Tests are excluded on purpose. They pass vi.fn() mocks where a full
+   * VercelResponse is expected, which is the normal shape of a handler test and
+   * would otherwise produce ~30 errors that say nothing about the shipped code.
+   * The point of this project is a gate on the handlers.
+   */
+  "exclude": ["api/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.api.json" }
   ]
 }


### PR DESCRIPTION
Two gaps that make "the checks are green" mean considerably less than it looks.

## CI ran nothing

The only workflow in this repo is `notify-desktop.yml`. The two checks on every
PR are **Vercel** and **Vercel Preview Comments** — a build and a deploy.
Nothing ran `npm run test` or `npm run lint`, so **a PR could break all 475
unit tests and every lint rule and still merge green.**

Adds `.github/workflows/ci.yml`: `npm ci` → `npm run build` → `npm run test` →
`npm run lint`, on `pull_request` and on `push` to `master`, Node 22, with
`concurrency` cancellation so superseded PR runs don't linger.

Lint is `continue-on-error` deliberately. `master` carries 29 pre-existing
problems and failing every PR on them would just train everyone to ignore the
job. Flip it to blocking once that backlog is cleared — 13 of the 29 are
`no-case-declarations` in one `switch` in `SaveModal.tsx`.

## `api/` was typechecked by nothing

`tsconfig.app.json` includes only `"src"`. `tsconfig.node.json` only
`"vite.config.ts"`. Vercel's builder transpiles serverless functions without
typechecking them. So roughly **8,000 lines** — every auth path, the SSRF
guards, the rate limiter, feed CRUD — had no type gate whatsoever. Verified
with `tsc --listFiles`: the app project pulls in **zero** files from `api/`.

CLAUDE.md's typechecking section warned that `tsc --noEmit` is a false green
and prescribed `npm run build` — but `npm run build` didn't cover `api/` either.
Corrected there too.

Adds `tsconfig.api.json` (Node types + DOM lib for the Web `fetch`/`Response`
types the handlers use, same strictness as the app project) and references it
from the root so `tsc -b` picks it up.

**The existing code is already clean**, so this is a missing gate rather than a
bug fix. I confirmed the gate actually bites by injecting
`const x: number = "not a number"` into `api/_utils/feedUtils.ts` and watching
the build fail with `TS2322`, then reverting.

`api/**/*.test.ts` is excluded: handler tests pass `vi.fn()` mocks where a full
`VercelResponse` is expected, which is normal for that style and produces ~30
errors that say nothing about shipped code.

## Testing

- `npm run build` ✅ (now covering `api/` for the first time)
- `npm run test` ✅ 475 passed
- Workflow YAML parsed and checked for correct triggers and step order

## Note on ordering

This is deliberately first in a series — it makes every subsequent PR
verifiable. Next up: the critical `fast-xml-parser` advisory, an
unauthenticated feed-takeover path, and a date round-trip that silently turns
11 March into 3 November.