### PR TITLE
Stop shipping 3.6 MB of logo to paint a 40px image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,11 @@ Hosted feed URLs (album/video/publisher) **always** use the canonical domain, ne
 - The inherited Squarespace zone was full of non-functional junk records (Office-365/Zoho/Google email templates with no MX, DKIM-as-A records). Pre-cleanup backup + keep/delete classification: `docs/dns-musicsideproject-backup-2026-06-17.txt`. Only 4 records are real: `@`/`www` (apex → MSP 2.0), `new` CNAME, and the `_vercel` verification TXTs.
 - Legacy MSP 1.0 feeds (from the old node-based tooling) are auto-migrated on import — see "Value recipient normalization on import" under XML Handling (`LEGACY_MSP_NODE_PUBKEY` → MSP 2.0 lnaddress).
 
+### Assets & caching
+- **Never import `src/assets/msp-logo.png` into a component.** It is a 1024x1024 PNG of **1,810,143 bytes**, byte-identical to `public/msp-logo.png` (same md5), and it renders at **40px** (`.header-logo`, `App.css`). Importing it bundled a *second* copy into `dist/assets/` while `public/` already served the first as the favicon, so a first visit pulled ~3.6 MB of logo against ~180 kB of compressed JS. `App.tsx` and `admin/AdminPage.tsx` now point at `/msp-logo-192.png` (66 kB) instead; measured `dist` total went 4,996,616 → 3,186,648 bytes. The full-size file stays for `og:image`, which only social crawlers fetch.
+- The unused `src/assets/msp-logo.png` is **deliberately not deleted**. The Desktop App is a fork with its own `App.tsx`; deleting an asset here breaks its build when the sync PR lands — see the fork-divergence gotcha above.
+- `vercel.json` gives `/assets/(.*)` `max-age=31536000, immutable`. Safe only because Vite content-hashes those filenames, so a URL's content can never change. **Don't extend it to `public/`** — `msp-logo*.png`, `manifest.json` and `info.md` have stable names and must stay revalidated.
+
 ### Versioning
 Version is auto-computed at build time from git commit count: `0.1.{count - 255}` (zero-padded). Each push to master increments the patch number. Configured in `vite.config.ts` via `getAutoVersion()`, with `package.json` version as fallback when git is unavailable. Displayed in the hamburger menu.
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/msp-logo.png" />
+    <!-- 66 kB, not the 1.8 MB original: this is a 32px tab icon. og:image below
+         keeps the full-size file, which only social crawlers fetch. -->
+    <link rel="icon" type="image/png" href="/msp-logo-192.png" />
     <link rel="apple-touch-icon" href="/msp-logo-192.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#8b5cf6" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,16 @@ import { PublisherEditor } from './components/Editor/PublisherEditor';
 import { AdminPage } from './components/admin/AdminPage';
 import { VerifyMagicLink } from './pages/VerifyMagicLink';
 import type { Album, Track } from './types/feed';
-import mspLogo from './assets/msp-logo.png';
+// The 40px header logo. Points at the 192px file in public/ rather than importing
+// assets/msp-logo.png, which is a 1024x1024 PNG weighing 1,810,143 bytes — the
+// same file public/ already serves as the favicon, so importing it shipped a
+// second byte-identical copy through the bundle and a first visit pulled ~3.6 MB
+// of logo against ~180 kB of compressed JS, all to paint a 40px image.
+//
+// assets/msp-logo.png is deliberately left in the repo: the Desktop App is a fork
+// with its own App.tsx, and deleting an asset upstream breaks its build when the
+// sync PR lands (see the fork-divergence note in CLAUDE.md).
+const mspLogo = '/msp-logo-192.png';
 import { PodcastIndexIcon } from './components/PodcastIndexIcon';
 import './App.css';
 

--- a/src/components/admin/AdminPage.tsx
+++ b/src/components/admin/AdminPage.tsx
@@ -1,7 +1,16 @@
 import { useState, useEffect } from 'react';
 import { useNostr } from '../../store/nostrStore';
 import { FeedList } from './FeedList';
-import mspLogo from '../../assets/msp-logo.png';
+// The 40px header logo. Points at the 192px file in public/ rather than importing
+// assets/msp-logo.png, which is a 1024x1024 PNG weighing 1,810,143 bytes — the
+// same file public/ already serves as the favicon, so importing it shipped a
+// second byte-identical copy through the bundle and a first visit pulled ~3.6 MB
+// of logo against ~180 kB of compressed JS, all to paint a 40px image.
+//
+// assets/msp-logo.png is deliberately left in the repo: the Desktop App is a fork
+// with its own App.tsx, and deleting an asset upstream breaks its build when the
+// sync PR lands (see the fork-divergence note in CLAUDE.md).
+const mspLogo = '/msp-logo-192.png';
 
 type AuthState = 'checking' | 'no-extension' | 'not-logged-in' | 'ready';
 

--- a/vercel.json
+++ b/vercel.json
@@ -10,5 +10,14 @@
   "rewrites": [
     { "source": "/admin", "destination": "/" },
     { "source": "/auth/verify", "destination": "/" }
+  ],
+  "headers": [
+    {
+      "comment": "Vite gives everything under /assets/ a content hash, so a given URL can never change content — but production was serving them 'public, max-age=0, must-revalidate', costing a conditional round-trip per asset on every single page load. Safe precisely because of the hash: a rebuild produces a new filename. Do NOT extend this to files in public/ (msp-logo*.png, manifest.json, info.md), which keep stable names and must stay revalidated.",
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,21 +2,34 @@
   "redirects": [
     {
       "source": "/((?!api/).*)",
-      "has": [{ "type": "host", "value": "msp.podtards.com" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "msp.podtards.com"
+        }
+      ],
       "destination": "https://musicsideproject.com/$1",
       "permanent": true
     }
   ],
   "rewrites": [
-    { "source": "/admin", "destination": "/" },
-    { "source": "/auth/verify", "destination": "/" }
+    {
+      "source": "/admin",
+      "destination": "/"
+    },
+    {
+      "source": "/auth/verify",
+      "destination": "/"
+    }
   ],
   "headers": [
     {
-      "comment": "Vite gives everything under /assets/ a content hash, so a given URL can never change content — but production was serving them 'public, max-age=0, must-revalidate', costing a conditional round-trip per asset on every single page load. Safe precisely because of the hash: a rebuild produces a new filename. Do NOT extend this to files in public/ (msp-logo*.png, manifest.json, info.md), which keep stable names and must stay revalidated.",
       "source": "/assets/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
       ]
     }
   ]


### PR DESCRIPTION
The single largest user-facing win available in the repo, with no behaviour
change.

## The problem

`public/msp-logo.png` and `src/assets/msp-logo.png` are **byte-identical** —
same md5 `aa145152…`, **1,810,143 bytes each**, 1024×1024 — and **both ship**:

- one as the favicon (`index.html:5`) and `og:image`
- one imported by `App.tsx:27` and `admin/AdminPage.tsx:4`, emitted again into
  `dist/assets/`

It renders at **40px** (`.header-logo`, `App.css:138`).

So a first visit downloaded **~3.6 MB of logo** against ~180 kB of brotli'd JS.
And production served it `cache-control: public, max-age=0, must-revalidate`,
so it was revalidated on every load after that.

## The fix

Both components and the favicon now point at `public/msp-logo-192.png` — 66 kB,
already in the repo, already the `apple-touch-icon`. `og:image` keeps the
full-size file; only social crawlers fetch that.

**Measured, not estimated:**

| | dist total |
|---|---|
| `master` | 4,996,616 bytes |
| this PR | **3,186,648 bytes** |

…plus the favicon request dropping from 1.81 MB to 66 kB on top of that.

## `src/assets/msp-logo.png` is deliberately left in place

It's now unused, and I'd normally delete it. But the Desktop App is a fork with
its own `App.tsx`, and CLAUDE.md's fork-divergence note records that deleting an
asset upstream breaks its build when the sync PR lands — it has bitten before.
Not worth breaking their CI to remove a file nothing loads.

## Immutable caching for `/assets/*`

`vercel.json` had no `headers` block, so every content-hashed asset was served
`max-age=0, must-revalidate` — a conditional round-trip per asset before first
paint, on every visit. Now `max-age=31536000, immutable`.

Safe **only** because Vite content-hashes those filenames, so a given URL's
content can never change; a rebuild produces a new name. Deliberately scoped to
`/assets/` — files in `public/` (`msp-logo*.png`, `manifest.json`, `info.md`)
have stable names and must stay revalidated. That constraint is written into
both the config and CLAUDE.md so it doesn't get widened by accident.

## Testing

- `npm run build` ✅ — confirmed the 1.81 MB PNG is gone from `dist/assets/`
- Verified `dist/msp-logo-192.png` exists (66,738 bytes) and the built HTML
  references it, and that `og:image` still resolves to the full-size file
- `npm run test` ✅ 491 passed
- Lint **unchanged from master** at 29 problems