### PR TITLE
Type the pisubmit test mocks instead of casting to any

### DIFF
--- a/api/pisubmit.test.ts
+++ b/api/pisubmit.test.ts
@@ -14,7 +14,11 @@ vi.mock('./_utils/feedReachability.js', () => ({
 function createMockReqRes(method: string, body: Record<string, unknown>) {
   const res = {
     status: vi.fn().mockReturnThis(),
-    json: vi.fn().mockReturnThis()
+    json: vi.fn().mockReturnThis(),
+    // Unused by this handler, but the Desktop App fork wraps the same handler in
+    // its CORS helper — which calls setHeader — and runs this exact test file.
+    // Stubbing it here costs nothing and saves that fork a per-sync patch.
+    setHeader: vi.fn().mockReturnThis()
   };
   return {
     req: { method, body, headers: {} } as unknown as VercelRequest,

--- a/api/pisubmit.test.ts
+++ b/api/pisubmit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
 
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
@@ -11,12 +12,16 @@ vi.mock('./_utils/feedReachability.js', () => ({
 }));
 
 function createMockReqRes(method: string, body: Record<string, unknown>) {
-  const req = { method, body, headers: {} } as any;
   const res = {
     status: vi.fn().mockReturnThis(),
     json: vi.fn().mockReturnThis()
-  } as any;
-  return { req, res };
+  };
+  return {
+    req: { method, body, headers: {} } as unknown as VercelRequest,
+    // Intersected rather than plain VercelResponse so the assertions below keep
+    // reaching res.json.mock while the handler still receives a VercelResponse.
+    res: res as unknown as VercelResponse & typeof res
+  };
 }
 
 describe('/api/pisubmit', () => {


### PR DESCRIPTION
The two `as any` casts in `api/pisubmit.test.ts` are the only lint errors in that file — and they break the desktop fork's build on every sync.

`MSP-2.0-Desktop-App` lints the same files with the same config, but as a **blocking** CI job, so `@typescript-eslint/no-explicit-any` is an error there that holds the automated sync PR open. Lint here is `continue-on-error: true` while the 29-problem backlog is worked through, so this landed unnoticed and has been the only thing keeping desktop sync PR #35 red on lint.

Typing `req` as `VercelRequest` and `res` as `VercelResponse & typeof res` keeps `res.json.mock.calls` reachable in the assertions while the handler still receives a real `VercelResponse` — the same shape the desktop fork already uses in `api/proxy-feed.test.ts`.

No behavior change: 7 tests pass, eslint clean on the file.

## Why fix it here rather than in the fork

A fix in the fork gets overwritten: the sync workflow force-pushes its `sync-upstream` branch on every push to this repo. Fixing it upstream, where it's a no-op, is what stops it recurring — same reasoning as the `ImportModal` hook-order reorder in 35ba36a.

Related: 7 more `no-explicit-any` and 13 `no-case-declarations` remain in the backlog. Clearing those and flipping the CI Lint step to blocking would close this failure mode at the source — happy to do that as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEfvKk9QFihD7iKn7N2tYC