### PR TITLE
Move CI off the deprecated Node 20 action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,12 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      # `cache: npm` stays explicit. setup-node v5 added automatic caching when
+      # package.json has a `packageManager` field — ours doesn't, so without this
+      # line the npm cache would silently stop being used rather than error.
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm


### PR DESCRIPTION
Every CI run currently prints:

> Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4

GitHub is already forcing them onto Node 24, so this is a warning about a migration that has effectively happened — but the forcing is temporary, and `ci.yml` is now a blocking gate for this repo *and* the file whose last edit crashed the Desktop App's sync. Worth not leaving on borrowed time.

Bumps `actions/checkout` and `actions/setup-node` from **v4 → v7** (current major, `runs.using: node24`).

## Breaking changes checked, none apply

I read the intervening majors rather than assuming:

- **setup-node v5** added automatic caching when `package.json` has a `packageManager` field. Ours doesn't (verified), and `cache: npm` is still set explicitly, so caching behaviour is identical. Added an inline note, because removing that line would now silently stop caching instead of failing.
- **checkout v7** blocks fork-PR checkout under `pull_request_target` / `workflow_run`. This workflow triggers on `pull_request` and `push` only.
- The related `allow-unsafe-pr-checkout` change was backported to **every** major including v4, so it isn't a reason to prefer one version over another.

Minimum runner for these is v2.327.1. GitHub-hosted runners are well past it and this repo uses none that are self-hosted.

## Verification

The real check is this PR's own `verify` run — it exercises both actions, and it's the same job that now enforces lint. YAML validated locally.

Companion PR ([#42](https://github.com/ChadFarrow/MSP-2.0-Desktop-App/pull/42)) bumps the Desktop App's 15 usages across `sync-upstream.yml`, `release.yml` and `test.yml` (including the `upload-artifact@v4` that isn't present here). Its `ci.yml` is deleted, so this change doesn't reach it via sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GiKeLVtfgMM3hELXWKPock