### PR TITLE
Don't sync docs-only commits to the Desktop App

### DIFF
--- a/.github/workflows/notify-desktop.yml
+++ b/.github/workflows/notify-desktop.yml
@@ -3,6 +3,16 @@ name: Notify Desktop App
 on:
   push:
     branches: [master]
+    # Each dispatch costs a sync run plus a full Tests fan-out in the Desktop App,
+    # and a docs-only commit changes nothing the fork builds from. Roughly 1 in 10
+    # commits here touches only markdown — CLAUDE.md is edited constantly.
+    #
+    # These are skipped rather than dropped: sync-upstream.yml's daily 6 AM cron
+    # still merges them, batched into whatever sync runs next, within 24h. So the
+    # fork never diverges, it just learns about prose a little later.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 jobs:
   notify:


### PR DESCRIPTION
Every push to master fires a repository_dispatch, and each one costs a
sync run plus a full Tests fan-out in the fork. A commit that touches
only markdown changes nothing the Desktop App builds from, and about 1
in 10 commits here is exactly that — CLAUDE.md is edited constantly.

Skip those pushes. They are not dropped: sync-upstream.yml's daily 6 AM
cron still merges them, batched into the next sync, so the fork picks
the prose up within 24h instead of paying for a dedicated run.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CVseyE54SQihBAJwnvGznD