### PR TITLE
Update the site docs to match the shipped app

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A web-based RSS feed editor for creating Podcasting 2.0 compatible music album f
 - Per-track value recipient overrides
 - Funding links for listener support (Patreon, Ko-fi, etc.)
 - Publisher reference linking (connect albums to a publisher feed)
+- Additional artwork via `<podcast:image>` — banners, canvas backgrounds, social cards at feed and track level, with dimensions auto-detected from the image
+- Track lyrics via `<podcast:transcript>` (SubRip, VTT, JSON and plain text)
+- Enclosure file sizes measured automatically (HEAD request, falling back to a duration-based estimate)
+- Track order kept in sync with pub dates — podcast apps sort newest-first, so track 1 carries the newest date. Imported feeds that are out of order get a one-click fix rather than a silent rewrite
 - Import/export feeds as XML
 - Local storage persistence
 
@@ -25,19 +29,26 @@ A web-based RSS feed editor for creating Podcasting 2.0 compatible music album f
 - Podcast Index integration (search and add feeds by name or GUID)
 - Bulk download catalog feeds with publisher references
 - Host publisher feeds on MSP with automatic Podcast Index notification
-- Nostr identity linking for token-free editing
+- Nostr or email identity linking for token-free editing
 
 ### Integrations
 - Nostr cloud sync (NIP-07 browser extension + NIP-46 remote signer)
 - Nostr Music publishing (kind 36787 track events + kind 34139 playlist) with NIP-09 unpublish
 - NIP-71 `naddr` video resolution (paste an `naddr` into a Video URL field to auto-fill)
 - Podcast Index search, feed submission, and pubnotify
-- MSP feed hosting with edit tokens and Nostr-linked ownership
+- MSP feed hosting with edit tokens, Nostr-linked and email-linked ownership
+- Email magic-link feed ownership — passwordless sign-in for people who don't use Nostr
 - Blossom server uploads (BUD-01) for file hosting
 - nsite (NIP-5A) publishing — decentralized feed hosting via Blossom + site manifest
 - OP3 analytics prefix support for privacy-respecting download stats
-- Podping broadcasts via self-hosted [podping-hivepinger](https://github.com/brianoflondon/podping-hivepinger) — auto-fires on Host on MSP updates; standalone toolbar button and Send Podping save destination for manual pings
+- Podping broadcasts via self-hosted [podping-hivepinger](https://github.com/brianoflondon/podping-hivepinger) — auto-fires on Host on MSP updates, with a standalone toolbar button for manual pings
+- Feed URL checking — pasted URLs are cleaned up, and MSP verifies a feed is actually reachable before submitting it to Podcast Index
 - Dark/light theme support
+
+### Experimental features
+A **Show Experimental Features** toggle in the hamburger menu (off by default) reveals
+the power-user options in the Import and Save modals. Anything marked 🧪 below is hidden
+until that toggle is on.
 
 ## Tech Stack
 
@@ -47,6 +58,8 @@ A web-based RSS feed editor for creating Podcasting 2.0 compatible music album f
 - Nostr (NIP-07, NIP-46, NIP-98)
 
 ## Project Structure
+
+Test files (`*.test.ts`) sit alongside the modules they cover and are omitted here.
 
 ```
 src/
@@ -67,13 +80,15 @@ src/
 │   │   ├── ImportModal.tsx         # Import feed modal
 │   │   ├── SaveModal.tsx           # Save options modal
 │   │   ├── PreviewModal.tsx        # Feed preview modal
-│   │   ├── InfoModal.tsx           # Info/about modal
+│   │   ├── InfoModal.tsx           # Info/about modal (renders public/info.md)
 │   │   ├── NostrConnectModal.tsx   # NIP-46 remote signer
 │   │   ├── NewFeedChoiceModal.tsx  # Start blank vs. use template
-│   │   ├── PodcastIndexModal.tsx   # Manual Podcast Index submission
 │   │   ├── PodpingModal.tsx        # Manual Podping broadcast (toolbar button)
 │   │   ├── ConfirmModal.tsx        # Confirmation dialog
 │   │   └── ModalWrapper.tsx        # Shared modal layout
+│   ├── auth/
+│   │   ├── EmailLoginModal.tsx     # Email magic-link login + feed claim
+│   │   └── SignInPrompt.tsx        # Sign-in nudge before hosting
 │   ├── admin/
 │   │   ├── AdminPage.tsx           # Admin panel
 │   │   ├── FeedList.tsx            # Feed management list
@@ -83,12 +98,17 @@ src/
 │   ├── FundingFields.tsx           # Funding link fields
 │   ├── InfoIcon.tsx                # Tooltip component
 │   ├── NostrLoginButton.tsx        # Nostr auth button
+│   ├── PodcastImagesList.tsx       # <podcast:image> additional artwork
+│   ├── PodcastIndexIcon.tsx        # Podcast Index toolbar mark
 │   ├── RecipientsList.tsx          # Value recipients with community support
 │   ├── Section.tsx                 # Collapsible section
 │   └── Toggle.tsx                  # Toggle switch
+├── pages/
+│   └── VerifyMagicLink.tsx         # /auth/verify magic-link landing page
 ├── store/
 │   ├── feedStore.tsx               # Album, video & publisher state
 │   ├── nostrStore.tsx              # Nostr auth state
+│   ├── experimentalStore.tsx       # Show Experimental Features toggle
 │   └── themeStore.tsx              # Dark/light theme state
 ├── types/
 │   ├── feed.ts                     # Album/track/publisher types
@@ -96,18 +116,28 @@ src/
 ├── utils/
 │   ├── addressUtils.ts             # Lightning address detection
 │   ├── adminAuth.ts                # Admin auth (client-side)
-│   ├── audioUtils.ts               # Audio duration/metadata
+│   ├── audioUtils.ts               # Audio duration + enclosure size detection
 │   ├── blossom.ts                  # Blossom server uploads
 │   ├── comparison.ts               # Value block comparison
-│   ├── dateUtils.ts                # RFC-822 date formatting
+│   ├── dateUtils.ts                # RFC-822 + Nostr `released` date formatting
+│   ├── emailSession.ts             # Email magic-link session handling
 │   ├── hostedFeed.ts               # MSP hosted feed management
+│   ├── imageMetadata.ts            # Image dimension/MIME detection
 │   ├── nostr.ts                    # Nostr key utilities
 │   ├── nostrMusicConverter.ts      # Album ↔ Nostr Music conversion
 │   ├── nostrRelay.ts               # Relay connection management
-│   ├── nostrSigner.ts              # NIP-46 remote signer
+│   ├── nostrSigner.ts              # NIP-46 remote signer + timeout wrappers
 │   ├── nostrSync.ts                # Relay sync (kind 30054)
+│   ├── nostrVideoConverter.ts      # NIP-71 naddr video resolution
+│   ├── nsite.ts                    # nsite (NIP-5A) publishing
 │   ├── publisherPublish.ts         # Publisher feed hosting
+│   ├── regenerateGuids.ts          # Fresh GUIDs for template imports
 │   ├── storage.ts                  # localStorage utilities
+│   ├── testData.ts                 # Dev-mode sample album generator
+│   ├── trackOrder.ts               # Track order ↔ pubDate sequencing
+│   ├── urlValidation.ts            # Feed URL normalization + rules
+│   ├── valueValidation.ts          # Value block guardrails
+│   ├── verifyFeedUrl.ts            # Feed reachability pre-flight
 │   ├── videoUtils.ts               # Video feed utilities
 │   ├── xmlGenerator.ts             # RSS XML generation
 │   └── xmlParser.ts                # RSS XML parsing
@@ -118,25 +148,47 @@ src/
 
 api/
 ├── _utils/
+│   ├── accountStore.ts             # Email account + magic-link blob storage
 │   ├── adminAuth.ts                # Nostr NIP-98 auth verification
+│   ├── emailAuth.ts                # Email session JWTs + email hashing
+│   ├── feedHydrate.ts              # Shared hosted-feed hydration
+│   ├── feedProbe.ts                # Shared feed reachability probe
+│   ├── feedReachability.ts         # Submit guard (refuses blocked feeds)
 │   ├── feedUtils.ts                # Shared feed utilities (PI + Podping)
 │   ├── podcastIndex.ts             # Podcast Index auth headers
 │   ├── rateLimiter.ts              # In-memory IP rate limiter
+│   ├── safeFetch.ts                # SSRF-checked fetch + redirect walking
+│   ├── sendEmail.ts                # Resend magic-link delivery
+│   ├── urlSafety.ts                # SSRF guards (private host/address checks)
+│   ├── urlValidation.ts            # Feed URL normalization (mirrors src/)
 │   └── xmlUtils.ts                 # RSS XML helpers (podcast:medium)
+├── account/
+│   └── feeds.ts                    # List an email account's feeds
 ├── admin/
 │   ├── challenge.ts                # Auth challenge generation
 │   └── verify.ts                   # Auth verification
+├── auth/
+│   ├── magic-link.ts               # Request a magic link
+│   └── verify.ts                   # Redeem a magic link → session
 ├── feed/
 │   └── [npub]/[guid].ts            # Nostr-stored feed retrieval
 ├── hosted/
 │   ├── index.ts                    # Create/list hosted feeds
 │   └── [feedId].ts                 # Get/update/delete hosted feeds
+├── example-feed.ts                 # Reference feed showing MSP's output
+├── op3check.ts                     # Whether OP3 has stats for a GUID
 ├── pisearch.ts                     # Podcast Index search
 ├── pisubmit.ts                     # Podcast Index feed submission
 ├── podping.ts                      # Manual podping broadcast (rate-limited)
+├── podping-verify.ts               # Check a podping landed on Hive
 ├── proxy-feed.ts                   # Feed proxy for CORS
-└── pubnotify.ts                    # Podcast Index pub notification
+├── pubnotify.ts                    # Podcast Index pub notification
+└── verify-feed-url.ts              # Feed reachability check
 ```
+
+Want to see what MSP actually produces? [`/api/example-feed`](https://musicsideproject.com/api/example-feed)
+serves a reference feed with Value 4 Value splits, person credits, track-level value
+overrides and lyrics.
 
 ## Development
 
@@ -144,6 +196,23 @@ api/
 npm install
 npm run dev
 ```
+
+| Command | What it does |
+| --- | --- |
+| `npm run dev` | Vite dev server (proxies `/api/*` to production) |
+| `npm run build` | TypeScript compile + Vite build |
+| `npm run lint` | ESLint |
+| `npm run test` | Run the test suite (Vitest) |
+| `npm run test:watch` | Vitest in watch mode |
+| `npm run preview` | Preview the production build |
+
+A `.env` file is required for the API functions (Podcast Index credentials, Vercel Blob
+token, Podping and email settings). There is no `.env.example` — see the Development
+section of `CLAUDE.md` for the full list, and ask the team for credentials.
+
+> **Typecheck with `npm run build`, not `tsc --noEmit`.** The root `tsconfig.json` is
+> references-only, so `tsc --noEmit` checks zero files and always passes. Use
+> `npm run build` or `npx tsc -b`.
 
 ## Publisher Mode
 
@@ -166,29 +235,42 @@ Once all your catalog feeds are hosted on MSP, the "Publish on MSP" section appe
 - **Upload File** - Upload an RSS/XML feed file from your device
 - **Paste XML** - Paste RSS/XML content directly
 - **From URL** - Fetch a feed from any URL
-- **Nostr Event** - Import from a Nostr Music event (kind 36787)
-- **MSP Hosted** - Load a feed hosted on MSP servers using its Feed ID
-- **From Nostr** - Load your previously saved feeds from Nostr (kind 30054, requires login)
+- **MSP Hosted** - Load a feed hosted on MSP servers using its Feed ID, or pick from your account's feeds
 - **From Nostr Music** - Import tracks from Nostr Music library (requires login)
+- **Nostr Event 🧪** - Import from a Nostr Music event (kind 36787)
+- **From Nostr 🧪** - Load your previously saved feeds from Nostr (kind 30054, requires login)
 - **naddr paste (Video mode)** - Paste a NIP-71 `naddr` (or a URL containing one) into a Video URL field to auto-resolve URL, MIME type, and duration
 
-## Save Options (Album/Video Mode)
+## Save Options
+
+There are nine destinations. Album and Video mode see all nine; Publisher mode sees the
+same list minus **Publish to Nostr Music**.
 
 - **Local Storage** - Save to your browser's local storage. Data persists until you clear browser data.
 - **Download XML** - Download the RSS feed as an XML file to your computer.
 - **Copy to Clipboard** - Copy the RSS XML to your clipboard for pasting elsewhere.
-- **Host on MSP** - Host your feed on MSP servers. Get a permanent subscribable URL (`https://msp.podtards.com/api/hosted/{feedId}`) to use in any podcast app.
-- **Save RSS feed to Nostr** - Embed the full RSS XML in a kind 30054 event for personal cross-device sync. Only MSP reads this event — not subscribable in podcast apps (requires login).
-- **Publish to Nostr Music** - Publish each track as a kind 36787 event plus a kind 34139 playlist event for Nostr-native music clients (Wavlake, Fountain, etc.). Includes an Unpublish button that sends a NIP-09 deletion request (requires login).
-- **Publish RSS feed to a Blossom server** - Upload your feed to a Blossom server with a kind 1063 (NIP-94) pointer event so `${origin}/api/feed/{npub}/{podcastGuid}.xml` always resolves to the latest upload. Subscribable in podcast apps (requires login).
-- **Publish RSS feed to nsite (experimental)** - Publish via Blossom + a NIP-5A site manifest (kind 35128). Subscribable via any nsite gateway URL, and auto-submitted to Podcast Index (requires login).
-- **Send Podping** - Broadcast a feed-update notification via Podping/Hive so indexers (Podcast Index, Fountain, etc.) re-crawl the feed. URL auto-fills from the current feed's hosted URL when available; editable for external feeds.
+- **Host on MSP** - Host your feed on MSP servers. Get a permanent subscribable URL (`https://musicsideproject.com/api/hosted/{feedId}.xml`) to use in any podcast app. Sign in with email or Nostr so the feed is owned by your account and editable from any device. Enable **Draft mode** to host without notifying Podcast Index or sending a podping.
+- **Submit to PodcastIndex** - Submit a feed URL to Podcast Index so it gets indexed and becomes discoverable in apps like Fountain, Castamatic, and others.
+- **Publish to Nostr Music** - Publish each track as a kind 36787 event plus a kind 34139 playlist event for Nostr-native music apps like Sunami. Audio files must already be hosted somewhere — the events just point at them. Includes an Unpublish button that sends a NIP-09 deletion request (requires login).
+- **Save RSS feed to Nostr 🧪** - Embed the full RSS XML in a kind 30054 event for personal cross-device sync. Only MSP reads this event — not subscribable in podcast apps (requires login).
+- **Publish RSS feed to a Blossom server 🧪** - Upload your feed to a Blossom server with a kind 1063 (NIP-94) pointer event so `${origin}/api/feed/{npub}/{podcastGuid}.xml` always resolves to the latest upload. Subscribable in podcast apps (requires login).
+- **Publish RSS feed to nsite 🧪** - Publish via Blossom + a NIP-5A site manifest (kind 35128). Subscribable via any nsite gateway URL, and auto-submitted to Podcast Index (requires login).
 
-## Save Options (Publisher Mode)
+Podping is not a save destination — it has its own button on the bottom toolbar.
 
-- **Local Storage** - Save publisher feed to browser storage.
-- **Download XML** - Download the publisher catalog feed as XML.
-- **Copy to Clipboard** - Copy the publisher feed XML.
+## Feed URLs
+
+Any field where you paste a feed URL gets two layers of help:
+
+- **Cleanup** — stray spaces, tabs, newlines and zero-width characters around the URL are
+  trimmed as you type. Whitespace *inside* the URL is reported rather than silently
+  removed, because deleting it would submit a URL you don't actually have — rename the
+  file at your host instead.
+- **Reachability** — before submitting to Podcast Index, MSP checks the feed actually
+  answers. This is advisory: a failed check warns you and relabels the button to
+  "Submit anyway", it never blocks you. A feed sitting behind bot protection is the case
+  worth heeding — it registers in Podcast Index and then stays permanently blank because
+  the crawler gets a 403.
 
 ## Nostr Integration
 
@@ -204,7 +286,26 @@ Default relays:
 - wss://relay.damus.io
 - wss://relay.primal.net
 - wss://nos.lol
-- wss://relay.nostr.band
+
+Nostr Music publishing (kinds 36787/34139) and its NIP-09 deletions additionally use
+`wss://drops.basspistol.org`, a public relay that only accepts music kinds.
+
+## Email Feed Ownership
+
+If you'd rather not use Nostr, you can own MSP-hosted feeds with just an email address.
+It's a third owner type alongside the edit token and Nostr — every hosted feed write
+accepts any of the three.
+
+- **Passwordless.** Enter your email, get a magic link, click it. No password to pick or forget.
+- **Your address is never stored.** MSP keeps only a keyed HMAC of it, so the raw email
+  isn't in the database to leak.
+- The link lands on `/auth/verify`, which redeems it once and hands back a session.
+- An existing feed can be **claimed** by proving you hold its edit token, which then ties
+  it to your email for good.
+
+Requires `RESEND_API_KEY`, `MSP_EMAIL_FROM`, `MSP_SESSION_SECRET` and `MSP_EMAIL_HASH_KEY`
+to be set, plus SPF/DKIM/DMARC records on the sending domain. Unconfigured, the feature
+cleanly no-ops.
 
 ## Podping
 
@@ -214,8 +315,19 @@ MSP broadcasts feed-update [Podpings](https://podping.org/) via a companion serv
 bearer-auth sidecar, deployed on Railway).
 
 - **Automatic**: every `Host on MSP` create/update fires a podping in the background
-- **Manual**: standalone **Podping** button on the bottom toolbar, or the **Send Podping** option in the Save modal
+- **Manual**: standalone **Podping** button on the bottom toolbar
 - **Direct API**: `GET /api/podping?url=<feedUrl>&reason=update` (rate-limited to 10/hour per IP)
+
+A 200 from the podping endpoint only means the ping was *queued* — the Hive broadcast is
+asynchronous. The manual Podping button therefore follows up by polling
+`/api/podping-verify` to confirm the ping actually landed on-chain, reporting
+"✅ Podping received", "Not received yet — it may still be queued", or "Couldn't check
+Hive right now". The automatic podpings stay fire-and-forget.
+
+Note that a delivered podping only tells indexers to go and look. If your own host then
+answers their crawler with a 403 (Cloudflare Bot Fight Mode is the usual culprit on
+WordPress sites), the feed registers and stays blank. That's what the reachability check
+above is guarding against.
 
 Requires two Vercel env vars to activate: `PODPING_ENDPOINT_URL` (Railway URL, trailing slash)
 and `PODPING_BEARER_TOKEN` (matches the service's `PODPING_SHARED_SECRET`). Both unset →

--- a/docs/rss-nostr-music-crossref.md
+++ b/docs/rss-nostr-music-crossref.md
@@ -8,7 +8,10 @@ A field-by-field mapping between the two formats MSP 2.0 emits from the same inp
 Canonical MSP source-of-truth for these mappings:
 
 - RSS generator — `src/utils/xmlGenerator.ts` (`generateRssFeed`, `generateTrackXml`, `generateCommonChannelElements`)
-- Nostr generator — `src/utils/nostrSync.ts` (`createMusicTrackEvent` at `:514`, `createMusicPlaylistEvent` at `:583`)
+- Nostr generator — `src/utils/nostrSync.ts` (`createMusicTrackEvent`, `createMusicPlaylistEvent`)
+- Nostr reader — `src/utils/nostrMusicConverter.ts` (`parseNostrMusicEvent`, `buildValueBlockFromZaps`)
+
+Function names rather than line numbers: pinned line numbers here drifted silently once already.
 
 ## Kinds used
 
@@ -21,6 +24,17 @@ Canonical MSP source-of-truth for these mappings:
 
 Kind `36787` and `34139` are MSP's current choice while [NIP-0a](https://github.com/nostr-protocol/nips/pull/1043) (kind `31337`) is unmerged. See `docs/nostr-music-nip-research.md` for the standardization status.
 
+### Relays
+
+Music events do not go to the same relays as everything else. `src/utils/nostrRelay.ts` defines:
+
+- `DEFAULT_RELAYS` — `relay.damus.io`, `relay.primal.net`, `nos.lol`
+- `MUSIC_RELAYS` — `DEFAULT_RELAYS` + `wss://drops.basspistol.org`
+
+`publishNostrMusicTracks`, `fetchNostrMusicTracks` and `deleteNostrMusicTracks` all default to
+`MUSIC_RELAYS`, because basspistol only accepts music kinds and would reject kind 0/30054/1063
+traffic. The relay *hint* embedded in a hex-pubkey zap tag is `DEFAULT_RELAYS[0]`.
+
 ---
 
 ## Track-level mapping (RSS `<item>` ↔ kind 36787)
@@ -29,22 +43,40 @@ Kind `36787` and `34139` are MSP's current choice while [NIP-0a](https://github.
 |---|---|---|---|
 | `track.guid` | `<guid isPermaLink="false">` | `["d", <guid>]` | Parameterized-replaceable identifier. Same string on both sides. |
 | `track.title` | `<title>` | `["title", <title>]` | |
-| `track.enclosureUrl` | `<enclosure url="…" type=… length=…/>` | `["url", <enclosureUrl>]` | Nostr drops `type` and `length`. If OP3 is enabled in RSS, the URL has an `https://op3.dev/e,pg={guid}/` prefix — strip it for Nostr round-trip. |
+| `track.enclosureUrl` | `<enclosure url="…" type=… length=…/>` | `["url", <enclosureUrl>]` | Nostr drops `type` and `length`. The OP3 prefix is applied at *generation* time and stripped at *parse* time, so `track.enclosureUrl` in MSP's state is always bare and needs no stripping here — a third-party implementer reading finished RSS does have to strip `https://op3.dev/e,pg={guid}/` themselves. |
 | `album.author` | `<itunes:author>` (channel) | `["artist", <author>]` | Artist lives on channel in RSS, on item in Nostr. |
 | `album.title` | `<title>` (channel) | `["album", <title>]` | Same "lifted from channel" pattern. |
-| `track.trackNumber` | `<podcast:episode>` (or `<itunes:episode>`) | `["track_number", <n>]` | MSP uses `<podcast:season>1</podcast:season>` + episode-as-track-number in RSS. |
+| `track.trackNumber` | `<podcast:episode>` | `["track_number", <n>]` | MSP emits `<podcast:season>1</podcast:season>` + `<podcast:episode>`, never `<itunes:episode>`. The episode value is `track.episode` when set, falling back to `track.trackNumber`. |
 | `track.duration` | `<itunes:duration>` | `["duration", <seconds>]` | RSS accepts `HH:MM:SS`; Nostr value is seconds as a string. |
 | `track.explicit` | `<itunes:explicit>true/false` | `["explicit", "true"]` | Only emitted on Nostr when `true`. |
-| `track.trackArtUrl` / `album.imageUrl` | `<itunes:image href>` (item; falls back to channel) + `<podcast:images srcset>` | `["image", <url>]` | Nostr uses item art if set, else album art. |
-| `track.pubDate` | `<pubDate>` (RFC-822) | `["released", "YYYY-MM-DD"]` | Different date format — convert on round-trip. |
+| `track.trackArtUrl` / `album.imageUrl` | `<itunes:image href>` (item; falls back to channel) | `["image", <url>]` | Nostr uses item art if set, else album art. The deprecated plural `<podcast:images srcset>` is no longer generated — `xmlParser.ts` still *reads* it for back-compat with older feeds. |
+| `track.podcastImages` / `album.podcastImages` | `<podcast:image href=… purpose=… alt=… aspect-ratio=… width=… height=… type=…/>` (channel and item) | *(not serialized)* | Additional artwork — banner, canvas, social card. RSS-only; see `PODCAST_IMAGE_PURPOSES` in `src/types/feed.ts`. |
+| `track.pubDate` | `<pubDate>` (RFC-822) | `["released", "MM/DD/YYYY"]` | Different date format — convert on round-trip. **`MM/DD`, not `DD/MM`**, and both ends read/write in **UTC** (`formatReleasedDate` / `parseReleasedDate` in `src/utils/dateUtils.ts`). The reader falls back to `DD/MM` only when the first component is >12, which is unambiguous. Getting this pair out of step is what made a publish→import round-trip swap month and day. |
 | `album.language` | `<language>` (channel) | `["language", <code>]` | Lifted from channel to item. |
 | `album.categories` | `<itunes:category text=…/>` (channel) | `["t", "music"]` + `["t", <cat-lowercased>]` per category | Nostr hashtags are always lowercased. `t=music` is always added as discriminator. |
-| value recipients (track override or album) | `<podcast:value>` + `<podcast:valueRecipient>` (item-level if override, else channel) | `["zap", <lnaddr-or-hex>, (<relay>,) <split>]` | Lightning address → `[zap, addr, split]`. Hex pubkey → `[zap, hex, relay, split]`. Node addresses that are neither are silently dropped. `customKey`/`customValue` are not serialized to Nostr. |
+| value recipients (track override or album) | `<podcast:value>` + `<podcast:valueRecipient>` (item-level if override, else channel) | `["zap", <lnaddr-or-hex>, (<relay>,) <split>]` | Lightning address → `[zap, addr, split]` (**3 elements, split at index 2**). Hex pubkey → `[zap, hex, relay, split]` (4 elements; the relay hint is `DEFAULT_RELAYS[0]`). Node addresses that are neither are silently dropped. `customKey`/`customValue` are not written. ⚠️ See the note below the table — MSP's own reader does not handle the 3-element form. |
 | `track.description` + `track.persons` | `<description>` + `<podcast:person group=… role=…>` (persons emitted at item level only when `track.overridePersons` is true; otherwise persons live on `<channel>`) | `content` field (plain text) | Description goes first, then a `Credits:` section with `Name: role1, role2` per line. Persons' `href` and `img` are not serialized to Nostr. |
 | — | — | `["client", "MSP 2.0"]` | Added by MSP; useful for consumers to filter/attribute. |
 | — | — | `["alt", "Music track: …"]` | NIP-31 fallback text for non-music clients. |
-| `track.transcriptUrl` / `transcriptType` | `<podcast:transcript url=… type=…/>` | *(not serialized)* | RSS-only. |
+| `track.transcriptUrl` / `transcriptType` | `<podcast:transcript url=… type=…/>` | *(not serialized)* | RSS-only. MSP's writer never emits a `Lyrics:` or `License:` section, but `parseNostrMusicContent` *reads* both so that events from other clients aren't lost — their text is folded into `track.description`. |
 | unknown item elements | preserved round-trip in RSS | *(not serialized)* | `track.unknownItemElements` only survives the RSS path. |
+
+### ⚠️ Lightning-address zap splits do not survive a round-trip
+
+The writer and the reader disagree about where the split lives. `buildZapTags` emits a
+**three**-element tag for a lightning address — `['zap', addr, split]`, split at index 2 —
+while `parseNostrMusicEvent` unconditionally reads `parseInt(t[3])`. For a 3-element tag
+that is `undefined` → `NaN` → `0`, and the recipient is then dropped by the
+`splitPercentage > 0` filter. Only hex-pubkey recipients (4-element tags) come back.
+
+This is a **code defect, described here as it currently behaves** — not the intended
+design. It is the same shape of writer/reader disagreement that caused the `released`
+date bug, so it is documented rather than papered over.
+
+A related asymmetry: recipients that *do* survive are rebuilt by `buildValueBlockFromZaps`
+as keysend **node** recipients with a fabricated `customKey` of `696969` and the pubkey as
+`customValue`. So `customKey`/`customValue` are not merely lost in the RSS → Nostr
+direction — they are *invented* coming back.
 
 ### Example: one track on each side
 
@@ -82,7 +114,7 @@ Nostr kind 36787:
     ["alt", "Music track: Hello World by The Band"],
     ["duration", "213"],
     ["image", "https://cdn.example.com/art.jpg"],
-    ["released", "2026-04-20"],
+    ["released", "04/20/2026"],
     ["language", "en"],
     ["t", "music"],
     ["t", "rock"],
@@ -117,7 +149,7 @@ Nostr kind 36787:
 | `album.ownerName`/`ownerEmail`, `managingEditor`, `webMaster`, `keywords`, `generator`, `lastBuildDate`, `pubDate` | standard RSS/iTunes elements | *(not serialized)* | RSS-only metadata. Nostr's `created_at` is the closest analog to `lastBuildDate`. |
 | `album.artistNpub` | `<podcast:txt purpose="npub">` | *(redundant; `pubkey` on the event is the signer)* | |
 | `album.publisher` | `<podcast:publisher><podcast:remoteItem .../></podcast:publisher>` | *(not serialized)* | Publisher graphs are RSS-only. |
-| `album.op3` | OP3 prefix applied to `<enclosure url>` | *(not serialized; strip before emitting Nostr)* | Analytics is an RSS-delivery concern. |
+| `album.op3` | OP3 prefix applied to `<enclosure url>` | *(not serialized)* | Analytics is an RSS-delivery concern. On import MSP sniffs an OP3 prefix on incoming Nostr URLs and re-enables `album.op3`, so feeds published by other tools keep their analytics setting. |
 | unknown channel elements | preserved round-trip in RSS | *(not serialized)* | |
 
 ### Example: playlist event
@@ -150,29 +182,32 @@ Nostr kind 36787:
 
 1. For each `<item>`: build a kind 36787 event using the table above. Copy `album.title` and `<itunes:author>` down into every track's `album` / `artist` tags.
 2. Lowercase `<itunes:category>` values for `t` tags; prepend `["t","music"]`.
-3. Convert `<pubDate>` (RFC-822) → `released` (`YYYY-MM-DD`).
+3. Convert `<pubDate>` (RFC-822) → `released` (`MM/DD/YYYY`, read out in UTC).
 4. Convert `<itunes:duration>` to integer seconds.
-5. Strip any `https://op3.dev/e…/` prefix from enclosure URLs.
+5. Strip any `https://op3.dev/e…/` prefix from enclosure URLs. (MSP itself has nothing to strip — it stores the bare URL and applies the prefix only when generating RSS.)
 6. Filter `<podcast:valueRecipient>` to only `lnaddress` or 64-hex-char `node` addresses; pick `[zap, addr, split]` vs `[zap, hex, relay, split]` based on format.
 7. Flatten `<podcast:person>` into a `Credits:` block in the event `content`.
 8. If 2+ tracks, build one kind 34139 event with `["a","36787:<pubkey>:<guid>"]` references in track order; d-tag = `<podcast:guid>`.
 
 **Nostr Music → RSS**
 
-1. Group kind 36787 events by their `album` tag (or by a shared kind 34139 playlist). Use the playlist's `d` tag as `<podcast:guid>`.
+1. Group kind 36787 events by their `album` tag. **MSP does not read kind 34139 at all** — it writes the playlist event but never queries for it (`fetchNostrMusicTracks` filters on the track kind only, and `groupTracksByAlbum` groups by the `album` tag). A consequence worth knowing: `<podcast:guid>` is *not* recovered on import, it is minted fresh by `createEmptyAlbum`, so an album's identity does not round-trip. An implementer who does read the playlist can use its `d` tag as `<podcast:guid>` and do better than MSP here.
+   Tracks with no `album` tag are collected under the name `Singles`.
 2. Channel: `album` → `<title>`, `artist` → `<itunes:author>`, `language` → `<language>`, `image` → `<itunes:image>`, playlist `description` → `<description>`, each `t` (except `music`) → `<itunes:category>`.
-3. Item per track: `title` → `<title>`, `url` → `<enclosure url>` (Nostr carries no MIME type or byte length — supply `type="audio/mpeg"` as a sensible default and either HEAD-request the URL for `length` or omit/zero it; note MSP's generator does not substitute a default for missing `enclosureType`, so be explicit), `duration` → `<itunes:duration>`, `released` (YYYY-MM-DD) → `<pubDate>` (RFC-822, midnight UTC), `d` → `<guid isPermaLink="false">`, `image` → `<itunes:image href>`, `explicit=true` → `<itunes:explicit>true`.
-4. Map `zap` tags back to `<podcast:valueRecipient>`. You won't recover `customKey`/`customValue`.
+3. Item per track: `title` → `<title>`, `url` → `<enclosure url>` (Nostr carries no MIME type or byte length — supply `type="audio/mpeg"` as a sensible default and either HEAD-request the URL for `length` or omit/zero it; note MSP's generator does not substitute a default for missing `enclosureType`, so be explicit), `duration` → `<itunes:duration>`, `released` (`MM/DD/YYYY`) → `<pubDate>` (RFC-822, midnight UTC), `d` → `<guid isPermaLink="false">`, `image` → `<itunes:image href>`, `explicit=true` → `<itunes:explicit>true`.
+4. Map `zap` tags back to `<podcast:valueRecipient>`. The originals' `customKey`/`customValue` are not recoverable — MSP substitutes a keysend `customKey` of `696969` with the pubkey as `customValue`. Read the lightning-address warning above before relying on this step: MSP's own reader drops 3-element `zap` tags.
 5. Split the first paragraph of `content` before `Credits:` back into `<description>`; parse the `Credits:` lines into `<podcast:person>` entries (group/role/href/img not recoverable without extra conventions).
-6. Fill `<podcast:medium>music</podcast:medium>` and set `<podcast:season>1</podcast:season>` + `<podcast:episode>{track_number}</podcast:episode>`.
+6. Fill `<podcast:medium>music</podcast:medium>` and set `<podcast:season>1</podcast:season>` + `<podcast:episode>{track_number}</podcast:episode>`. Season is hardcoded to `1`.
+
+Other import-side limits worth knowing, all in `nostrMusicConverter.ts`: categories are truncated to the first **5**; a `duration` tag is ignored unless it is all digits; and the album description is synthesized from the first track that carries credits rather than read from a playlist event.
 
 ## Data loss, by direction
 
-**Lost going RSS → Nostr:** transcripts, funding, locked, publisher links, medium, owner contact info, keywords, managingEditor/webMaster, person `href`/`img`, value recipient `customKey`/`customValue`, enclosure `type` and `length`, OP3 routing, season, `<podcast:images>` `srcset`, any unknown-namespace elements.
+**Lost going RSS → Nostr:** transcripts/lyrics, funding, locked, publisher links, medium, owner contact info, keywords, managingEditor/webMaster, person `href`/`img`, value recipient `customKey`/`customValue`, enclosure `type` and `length`, OP3 routing, season, `<podcast:image>` additional artwork (`podcastImages`), any unknown-namespace elements.
 
-**Lost going Nostr → RSS:** `client`, `alt`, `public`, NIP-09 deletion semantics (RSS has no "retract this item"), the cryptographic signature itself.
+**Lost going Nostr → RSS:** `client`, `alt`, `public`, NIP-09 deletion semantics (RSS has no "retract this item"), the cryptographic signature itself, the album's `<podcast:guid>` (regenerated, because MSP never reads the playlist event), and — through the defect noted above — every lightning-address zap split.
 
-**Preserved on both sides:** track `guid` / `d`, album `podcastGuid` / playlist `d`, title, enclosure/url, artist, album, track number, duration, explicit flag, release date, image, language, categories (as lowercased hashtags), Lightning zap splits (for lnaddress/hex-pubkey recipients).
+**Preserved on both sides:** track `guid` / `d`, title, enclosure/url, artist, album, track number, duration, explicit flag, release date, image, language, categories (as lowercased hashtags, first 5), and zap splits **for hex-pubkey recipients only**.
 
 ---
 

--- a/public/info.md
+++ b/public/info.md
@@ -1,8 +1,8 @@
 # What is MSP 2.0?
 
-This is an updated version on the original [Music Side Project](https://www.musicsideproject.com/) by the legendary StevenB. Actually most of whats written below came from the original site and I just edited it some.
+This is an updated version on the original [Music Side Project](https://github.com/ChadFarrow/msp-studio) by the legendary StevenB. The original has been retired and archived (this site now runs on its old address), but the source is still up there to look at. Actually most of whats written below came from the original site and I just edited it some.
 
-The original version still works great but I felt like it needed updated since the landscape has changed so much over the years. 
+The original version worked great but I felt like it needed updated since the landscape has changed so much over the years.
 
 TLDR this is a simple web form that lets you build a RSS feed for your music.
 
@@ -28,7 +28,9 @@ But, you're musicians, you're used to booking your own gigs, hauling your own ge
 
 ### How is MSP 2.0 Different?
 
-Really its the same since its building PC 2.0 RSS feeds but MSP has always been missing the hosting part, you make your feed and then what? I've got some ideas on how to do this but I wont really know know how until I build it.
+Really its the same since its building PC 2.0 RSS feeds, but MSP has always been missing the hosting part - you make your feed and then what? That part is built now. MSP 2.0 can host the feed for you and hand you back a permanent link you can hand to any podcast app, and it tells the Podcast Index about it so people can actually find it. You claim the feed with an email address or a Nostr key, so it stays yours and you can come back and edit it from any device.
+
+You still don't have to use any of that. Download the XML and host it yourself - that's the whole point and it isn't going away.
 
 Any questions reach out.
 
@@ -41,21 +43,3 @@ Twitter/X - https://x.com/msp2app
 Nostr - npub177fz5zkm87jdmf0we2nz7mm7uc2e7l64uzqrv6rvdrsg8qkrg7yqx0aaq7
 
 Email - SirChadF@proton.me
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
README.md and public/info.md were last touched in late June; roughly twenty
commits have landed since, and parts of both had become actively wrong rather
than merely incomplete.

README:
- Fix the hosted feed URL — it gave the legacy msp.podtards.com domain and
  omitted the .xml extension, so the one URL a musician is most likely to copy
  out of the README was wrong twice over
- Drop the "Send Podping" save destination and PodcastIndexModal.tsx, neither of
  which still exists; add "Submit to PodcastIndex", which does
- Correct the Nostr Music consumer from "Wavlake, Fountain" to Sunami — those
  are PC 2.0 apps that don't play Nostr-native music. The in-app help already
  said this
- Correct the publisher-mode save list: it sees every destination except
  Nostr Music, not just the three local ones
- Drop relay.nostr.band from the default relays (commented out as unreachable)
  and document MUSIC_RELAYS
- Mark experimental import/save options and explain the toggle that reveals them
- Regenerate the project tree; verified complete in both directions against the
  real source files
- Document email feed ownership, feed URL checking, podping on-chain
  verification, podcast:image, lyrics, enclosure sizing and track-order syncing
- Expand Development with the real scripts, the .env requirement, and the
  warning that tsc --noEmit is a false green against a references-only tsconfig

public/info.md:
- The "original Music Side Project" link pointed at musicsideproject.com, which
  now serves MSP 2.0 itself; point it at the read-only archive
- Rewrite the "hosting is still missing" paragraph — hosting shipped

docs/rss-nostr-music-crossref.md:
- The `released` tag is MM/DD/YYYY read and written in UTC, not YYYY-MM-DD;
  this was wrong in four places and describes the exact writer/reader
  disagreement that caused an earlier date bug
- Record that lightning-address zap splits do not survive a round-trip: the
  writer emits a 3-element tag and the reader reads index 3, so the split
  parses as 0 and is filtered out. Documented as current behavior, not intent
- Record that MSP never reads kind 34139, so podcastGuid does not round-trip
- podcast:images (plural) is no longer generated; add podcast:image
- Add a relays section, and correct the OP3, customKey and itunes:episode claims
- Replace line-number citations with function names, which had already drifted

docs/nostr-music-nip-research.md is left alone: its NIP-0a status is a dated
snapshot and this environment can't reach the upstream repo to re-verify it.
The docs/superpowers plans and specs and the DNS backup are dated artifacts and
are deliberately untouched.

Co-Authored-By: Claude <noreply@anthropic.com>